### PR TITLE
Yield-style generator examples.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,35 @@ sieve_wasmfx.wasm: inc/fiber.h src/wasmfx/imports.wat src/wasmfx/wasmfx_impl.c e
 	$(WASM_MERGE) fiber_wasmfx_imports.wasm "fiber_wasmfx_imports" sieve_wasmfx.pre.wasm "main" -o sieve_wasmfx.wasm
 	chmod +x sieve_wasmfx.wasm
 
+.PHONY: itersum
+itersum: itersum_asyncify.wasm itersum_wasmfx.wasm
+
+itersum_asyncify.wasm: inc/fiber.h src/asyncify/asyncify_impl.c examples/itersum.c
+	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_impl.c $(WASIFLAGS) examples/itersum.c -o itersum_asyncfiy.pre.wasm
+	$(ASYNCIFY) itersum_asyncfiy.pre.wasm -o itersum_asyncify.wasm
+	chmod +x itersum_asyncify.wasm
+
+itersum_wasmfx.wasm: inc/fiber.h src/wasmfx/imports.wat src/wasmfx/wasmfx_impl.c examples/itersum.c
+	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_impl.c $(WASIFLAGS) examples/itersum.c -o itersum_wasmfx.pre.wasm
+	$(WASM_INTERP) -d -i src/wasmfx/imports.wat -o fiber_wasmfx_imports.wasm
+	$(WASM_MERGE) fiber_wasmfx_imports.wasm "fiber_wasmfx_imports" itersum_wasmfx.pre.wasm "main" -o itersum_wasmfx.wasm
+	chmod +x itersum_wasmfx.wasm
+
+.PHONY: treesum
+treesum: treesum_asyncify.wasm treesum_wasmfx.wasm
+
+treesum_asyncify.wasm: inc/fiber.h src/asyncify/asyncify_impl.c examples/treesum.c
+	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_impl.c $(WASIFLAGS) examples/treesum.c -o treesum_asyncfiy.pre.wasm
+	$(ASYNCIFY) treesum_asyncfiy.pre.wasm -o treesum_asyncify.wasm
+	chmod +x treesum_asyncify.wasm
+
+treesum_wasmfx.wasm: inc/fiber.h src/wasmfx/imports.wat src/wasmfx/wasmfx_impl.c examples/treesum.c
+	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_impl.c $(WASIFLAGS) examples/treesum.c -o treesum_wasmfx.pre.wasm
+	$(WASM_INTERP) -d -i src/wasmfx/imports.wat -o fiber_wasmfx_imports.wasm
+	$(WASM_MERGE) fiber_wasmfx_imports.wasm "fiber_wasmfx_imports" treesum_wasmfx.pre.wasm "main" -o treesum_wasmfx.wasm
+	chmod +x treesum_wasmfx.wasm
+
+
 src/wasmfx/imports.wat: src/wasmfx/imports.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports.wat
 

--- a/examples/itersum.c
+++ b/examples/itersum.c
@@ -1,0 +1,47 @@
+// Iterative sum; an iterative variation of `treesum.c`
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fiber.h>
+
+
+void* sum(void *arg) {
+  int32_t max = (int32_t)(intptr_t)arg;
+  for (int32_t i = 0; i < max; i++) {
+    fiber_yield((void*)(intptr_t)i);
+  }
+  return NULL;
+}
+
+int32_t run(int32_t max) {
+  fiber_result_t status;
+  fiber_t gen = fiber_alloc(sum);
+  int32_t result = 0, i = 0;
+
+  void* val = fiber_resume(gen, (void*)(intptr_t)i, &status);
+
+  while (status == FIBER_YIELD && i++ < max) {
+    result += (int32_t)(intptr_t)val;
+    val = fiber_resume(gen, NULL, &status);
+  }
+
+  fiber_free(gen);
+  return result;
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    fprintf(stderr, "Wrong number of arguments. Expected: 1");
+    return -1;
+  }
+  fiber_init();
+
+  int i = atoi(argv[1]);
+
+  int32_t result = run(i);
+
+  printf("%d\n", result);
+
+  fiber_finalize();
+  return 0;
+}

--- a/examples/treesum.c
+++ b/examples/treesum.c
@@ -1,0 +1,91 @@
+// Tree traversal; a recursive variation of `itersum.c`
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fiber.h>
+
+typedef struct node {
+  enum { LEAF, FORK } tag;
+  union {
+    // Leaf.
+    int32_t val;
+    // Fork
+    struct {
+      struct node *left;
+      struct node *right;
+    };
+  };
+} node_t;
+
+node_t* build_tree(int32_t depth, int32_t val) {
+  node_t *node = (node_t*)malloc(sizeof(node_t));
+  if (depth == 0) {
+    node->tag = LEAF;
+    node->val = val;
+  } else {
+    node->tag = FORK;
+    node_t *subtree = build_tree(depth - 1, val + 1);
+    node->left = subtree;
+    node->right = subtree;
+  }
+  return node;
+}
+
+void free_tree(node_t *node) {
+  enum { LEAF, FORK } tag = node->tag;
+  if (tag == FORK) {
+    free_tree(node->left);
+    free_tree(node->right);
+  }
+  free(node);
+}
+
+void walk_tree(node_t *node) {
+  if (node->tag == LEAF) {
+    fiber_yield((void*)(intptr_t)node->val);
+  } else {
+    walk_tree(node->left);
+    walk_tree(node->right);
+  }
+}
+
+void* tree_walker(void *node) {
+  walk_tree((node_t*)node);
+  return NULL;
+}
+
+int32_t run(node_t* tree) {
+  fiber_result_t status;
+  int32_t sum = 0;
+  fiber_t walker = fiber_alloc(tree_walker);
+
+  void* val = fiber_resume(walker, (void*)tree, &status);
+
+  while (status == FIBER_YIELD) {
+    sum += (int32_t)(intptr_t)val;
+    val = fiber_resume(walker, NULL, &status);
+  }
+
+  fiber_free(walker);
+  return sum;
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    fprintf(stderr, "Wrong number of arguments. Expected: 1");
+    return -1;
+  }
+  fiber_init();
+
+  int i = atoi(argv[1]);
+  node_t *tree = build_tree((int32_t)i, 0);
+
+  int32_t result = run(tree);
+
+  free_tree(tree);
+
+  printf("%d\n", result);
+
+  fiber_finalize();
+  return 0;
+}


### PR DESCRIPTION
This patch adds two similar examples which sums a sequence of numbers, where the sequence is generated by a yield-style generator. The first example uses an iterative loop to generate the sequence, whereas the second example generates the sequence by recursion on a binary tree.