### PR TITLE
Abstract `fiber_{init,finalize}`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ WASMFX_PRESERVE_SHADOW_STACK?=1
 # Only relevant if WASMFX_PRESERVE_SHADOW_STACK is 1
 WASMFX_CONT_SHADOW_STACK_SIZE?=65536
 ASYNCIFY=../binaryen/bin/wasm-opt --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 --asyncify
-WASICC=../benchfx/wasi-sdk-22.0/bin/clang
+WASICC=../benchfx/wasi-sdk-25.0-x86_64-linux/bin/clang
 WASIFLAGS=--sysroot=../benchfx/wasi-sdk-22.0/share/wasi-sysroot -std=c17 -Wall -Wextra -Werror -Wpedantic -Wno-strict-prototypes -O3 -I inc
 WASM_INTERP=../spec/interpreter/wasm
 WASM_MERGE=../binaryen/bin/wasm-merge --enable-multimemory --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -30,8 +30,7 @@ void* world(void *arg) {
   return NULL;
 }
 
-int main(void) {
-  fiber_init();
+int prog(int __attribute__((unused)) argc, char** __attribute__((unused)) argv) {
   fiber_result_t status;
   fiber_t hello_fiber = fiber_alloc(hello);
   fiber_t world_fiber = fiber_alloc(world);
@@ -61,6 +60,9 @@ int main(void) {
   fiber_free(hello_fiber);
   fiber_free(world_fiber);
 
-  fiber_finalize();
   return 0;
+}
+
+int main(int argc, char** argv) {
+  return fiber_main(prog, argc, argv);
 }

--- a/examples/itersum.c
+++ b/examples/itersum.c
@@ -29,12 +29,11 @@ int32_t run(int32_t max) {
   return result;
 }
 
-int main(int argc, char** argv) {
+int prog(int argc, char** argv) {
   if (argc != 2) {
     fprintf(stderr, "Wrong number of arguments. Expected: 1");
     return -1;
   }
-  fiber_init();
 
   int i = atoi(argv[1]);
 
@@ -42,6 +41,9 @@ int main(int argc, char** argv) {
 
   printf("%d\n", result);
 
-  fiber_finalize();
   return 0;
+}
+
+int main(int argc, char** argv) {
+  return fiber_main(prog, argc, argv);
 }

--- a/examples/sieve.c
+++ b/examples/sieve.c
@@ -34,7 +34,7 @@ static void print_input_error_and_exit(void) {
   exit(1);
 }
 
-int main(int argc, char **argv) {
+int prog(int argc, char **argv) {
   if (argc != 2) {
     printf("usage: %s <n>\n", argv[0]);
     exit(1);
@@ -53,7 +53,6 @@ int main(int argc, char **argv) {
   uint32_t p = 0;                         // number of primes computed so far.
   int32_t i = 2;                          // the current candidate prime number.
 
-  fiber_init();
   fiber_t *filters = (fiber_t*)malloc(sizeof(fiber_t) * max_primes);
   fiber_result_t status;
 
@@ -91,7 +90,10 @@ int main(int argc, char **argv) {
     fiber_free(filters[i]);
   }
   free(filters);
-  fiber_finalize();
 
   return 0;
+}
+
+int main(int argc, char** argv) {
+  return fiber_main(prog, argc, argv);
 }

--- a/examples/treesum.c
+++ b/examples/treesum.c
@@ -70,12 +70,11 @@ int32_t run(node_t* tree) {
   return sum;
 }
 
-int main(int argc, char** argv) {
+int prog(int argc, char** argv) {
   if (argc != 2) {
     fprintf(stderr, "Wrong number of arguments. Expected: 1");
     return -1;
   }
-  fiber_init();
 
   int i = atoi(argv[1]);
   node_t *tree = build_tree((int32_t)i, 0);
@@ -86,6 +85,9 @@ int main(int argc, char** argv) {
 
   printf("%d\n", result);
 
-  fiber_finalize();
   return 0;
+}
+
+int main(int argc, char** argv) {
+  return fiber_main(prog, argc, argv);
 }

--- a/inc/fiber.h
+++ b/inc/fiber.h
@@ -35,15 +35,9 @@ export("fiber_resume")
 void* fiber_resume(fiber_t fiber, void *arg, fiber_result_t *status);
 
 
-/** Initialises the fiber runtime. It must be called exactly once
-    before using any of the other fiber_* functions. **/
-export("fiber_init")
-void fiber_init(void);
-
-/** Tears down the fiber runtime. It must be called after the final
-    use of any of the other fiber_* functions. **/
-export("fiber_finalize")
-void fiber_finalize(void);
+/** Runs the provided `main` function in a fiber context. **/
+export("fiber_main")
+int fiber_main(int (*main)(int,char**), int, char**);
 
 #undef export
 #endif

--- a/src/asyncify/asyncify_impl.c
+++ b/src/asyncify/asyncify_impl.c
@@ -226,4 +226,11 @@ void fiber_finalize(void) {
 #endif
 }
 
+int fiber_main(int (*main)(int, char**), int argc, char** argv) {
+  fiber_init();
+  int ans = main(argc, argv);
+  fiber_finalize();
+  return ans;
+}
+
 #undef import

--- a/src/wasmfx/wasmfx_impl.c
+++ b/src/wasmfx/wasmfx_impl.c
@@ -174,4 +174,11 @@ void fiber_finalize(void) {
 #endif
 }
 
+int fiber_main(int (*main)(int, char**), int argc, char** argv) {
+  fiber_init();
+  int ans = main(argc, argv);
+  fiber_finalize();
+  return ans;
+}
+
 #undef import


### PR DESCRIPTION
This patch abstracts away the fiber runtime initialisation and finalisation procedures.