### PR TITLE
Refactored and added `total-stacks` argument in wasmtime run-scripts

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -18,8 +18,8 @@ config = yaml.safe_load(open("config.yml"))
 all_benchmarks = config["BENCHMARKS_FIBER_C"]
 all_engines = config["ENGINES"]
 
-def call_buildscript(benchmark: str):
-    subprocess.check_call(["./build.py", "--make", benchmark])
+def call_buildscript():
+    subprocess.check_call(["./build.py"])
     
 def run_benchmarks(benchmarks, engines):
     # call hyperfine to run wasmfx benchmarks
@@ -28,7 +28,6 @@ def run_benchmarks(benchmarks, engines):
     subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", "bench_results/asyncify_results.json", "--export-csv", "bench_results/asyncify_results.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
 
 def main():
-
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--benchmarks", nargs="*", help="List of benchmarks to run (sieve, itersum, treesum)", 
@@ -46,17 +45,17 @@ def main():
     if not set(args.engines).issubset(set(all_engines)):
         raise ValueError(f"Error: invalid engine name(s). Valid options are: {', '.join(all_engines)}")
 
-    for benchmark in args.benchmarks:
-        call_buildscript(benchmark)
-
+    # build and run everything
+    call_buildscript()
     os.makedirs("bench_results", exist_ok=True)
     run_benchmarks(args.benchmarks, args.engines)
+
      # make chart
     os.system(f"python3 plot_benchmarks.py bench_results/wasmfx_results.json bench_results/asyncify_results.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/results")
     # make a copy of the chart in the root directory of ehop machine for webserver reasons
     shutil.copytree("bench_results", "/opt/wasmfx/bench_results_page", dirs_exist_ok=True)
     # clean up .wasm files and scripts
-    subprocess.check_call(["./build.py", "--clean-all"])
+    subprocess.check_call(["make", "clean"])
 
 if __name__ == "__main__":
     main()

--- a/build.py
+++ b/build.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 """
-Buildscript that compiles wasm binaries for fiber-c benchmarks, and generates scripts to run them on the three wasm engines of interest
-(d8, wasmtime, and wizard). The generated scripts are in /run-scripts and can be executed with `./run-scripts/benchmark_engine_mode.sh`,
+Buildscript that generates scripts to run them on the three wasm engines of interest (d8, wasmtime, and wizard). 
+The generated scripts are in /run-scripts and can be executed with `./run-scripts/benchmark_engine_mode.sh`,
 e.g. `./run-scripts/sieve1_d8_wasmfx.sh`.
 Usage:  `./build.py --help`
-        `./build.py --make-all`
-        `./build.py --make sieve1 --engines d8 wasmtime`
-        `./build.py --clean-all`
+        `./build.py --engines d8 wasmtime` to only generate scripts for d8 and wasmtime.
 """
 
 import argparse
@@ -17,33 +15,14 @@ from pathlib import Path
 
 # Import config
 config = yaml.safe_load(open("config.yml"))
-BENCHMARKS = config["BENCHMARKS_FIBER_C"]
 
 # Given a benchmark name, build .wasm files for both asyncify and wasmfx modes.
-# TODO: Move the output files to a more sensible directory, such as /benchfx/out/benchmark_name
-def build_benchmarks(benchmark: str):
-    subprocess.run(["make", f"BENCHMARK={benchmark}"])
-
-def clean_all():
-    subprocess.run(["make", "clean"])
+def build_benchmarks():
+    subprocess.run(["make", "all"])
 
 # ---- Script generation ----
-ENGINES = {
-    "wasmtime": {
-        "asyncify": "{prefix} setarch -R {wasmtime} run --allow-precompiled -W=exceptions,function-references,gc,stack-switching {benchmark}_asyncify.cwasm {arg}",
-        "wasmfx": "{prefix} setarch -R {wasmtime} run --allow-precompiled -W=exceptions,function-references,gc,stack-switching {benchmark}_wasmfx.cwasm {arg}"
-    },
 
-    "d8": {
-        "asyncify": "{prefix} setarch -R {d8} --experimental-wasm-wasmfx {v8_js_loader} -- {benchmark}_asyncify.wasm {arg}",
-        "wasmfx": "{prefix} setarch -R {d8} --experimental-wasm-wasmfx {v8_js_loader} -- {benchmark}_wasmfx.wasm {arg}",
-    },
-
-    "wizard": {
-        "asyncify": "{prefix} setarch -R {wizard} {wizard_flags} --mode=jit {benchmark}_asyncify.wasm {arg}",
-        "wasmfx": "{prefix} setarch -R {wizard} {wizard_flags} --mode=jit {benchmark}_wasmfx.wasm {arg}",
-    },
-}
+SCRIPT_TEMPLATE = f"#!/bin/bash\n setarch -R {{engine_path}} {{engine_options}} out/{{benchmark}}_{{mode}}.{{suffix}} {{arg}}"
 
 def make_script(filename: Path, content: str):
     filename.write_text(content)
@@ -55,71 +34,57 @@ def generate_scripts(benchmark: str, engines: list[str]):
         arg = config["ITERSUM_ARGS"]
     elif benchmark in {"treesum", "treesum_switch"}:
         arg = config["TREESUM_ARGS"]
-    elif benchmark in {"sieve1", "sieve1_switch"}:
-        arg = config["SIEVE1_ARGS"]
+    elif benchmark in {"sieve", "sieve_switch"}:
+        arg = config["SIEVE_ARGS"]
     else:
         arg = ""
 
     Path("run-scripts").mkdir(exist_ok=True)
+
+    # Generate scripts that run each benchmark using SCRIPT_TEMPLATE and data from config.yml
     for engine in engines:
-        for mode, template in ENGINES[engine].items():
+        for mode in ["asyncify", "wasmfx"]:
             script_name = f"{benchmark}_{engine}_{mode}.sh"
-            content = template.format(
-                prefix=config["PREFIX"],
+            # configure engine-specific options and script suffixes
+            match engine:
+                case "wasmtime":
+                    engine_path=config["WASMTIME_PATH"]
+                    suffix="cwasm"
+                    # Set up stack pool size for the benchmarks that need a specific number
+                    if benchmark in config["WASMTIME_STACK_POOL_SIZES"].keys():
+                        engine_options = f"{config['WASMTIME_OPTIONS']},total-stacks={config['WASMTIME_STACK_POOL_SIZES'][benchmark]}"
+                    else:
+                        engine_options=config["WASMTIME_OPTIONS"]
+                case "wizard":
+                    engine_path=config["WIZARD_PATH"]
+                    engine_options=config["WIZARD_OPTIONS"]
+                    suffix="wasm"
+                case "d8":
+                    engine_path=config["D8_PATH"]
+                    engine_options=config["D8_OPTIONS"]
+                    suffix="wasm"
+            # stick this all into the script template       
+            content = SCRIPT_TEMPLATE.format(
+                engine_path=engine_path,
+                engine_options=engine_options,
                 benchmark=benchmark,
-                wasmtime=config["WASMTIME_PATH"],
-                d8=config["D8_PATH"],
-                wizard=config["WIZARD_PATH"],
-                v8_js_loader=config["V8_JS_LOADER"],
-                arg=arg,
-                wizard_flags=config["WIZARD_FLAGS"],
+                mode=mode,
+                suffix=suffix,
+                arg=arg, 
             )
             make_script(Path("run-scripts/" + script_name), content)
-
-def benchmark_validation(benchmarks):
-    for benchmark in benchmarks:
-        if benchmark not in BENCHMARKS:
-            raise ValueError(f"Error: Benchmark '{benchmark}' is not recognized.")
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--make-all", action="store_true", help="Build and generate scripts for all benchmarks"
+        "--engines", nargs="*", choices=list(config["ENGINES"]), help="Build and generate scripts for specified engine(s)",
+        default=config["ENGINES"]
     )
-    parser.add_argument(
-        "--clean-all", action="store_true", help="Clean all build artefacts"
-    )
-    parser.add_argument(
-        "--make", nargs="*", help="Build and generate scripts for specified benchmark(s)",
-        default=None
-    )
-    parser.add_argument(
-        "--engines", nargs="*", choices=list(ENGINES.keys()), help="Build and generate scripts for specified engine(s)",
-        default=ENGINES.keys()
-    )
-
     args = parser.parse_args()
-
-    if not (args.make_all or args.clean_all or args.make):
-        print("Error: Must specify at least one of --make-all, --clean-all, --make")
-        sys.exit(1)
-
-    if args.make_all:
-        for benchmark in BENCHMARKS:
-            print("Building benchmark:", benchmark)
-            build_benchmarks(benchmark)
-            generate_scripts(benchmark,args.engines)
-            print("Built .wasm files and generated scripts for benchmark:", benchmark)
-    elif args.clean_all:
-        clean_all()
-    elif args.make:
-        benchmark_validation(args.make)
-        for benchmark in args.make:
-            build_benchmarks(benchmark)
-            generate_scripts(benchmark,args.engines)
-            print("Built .wasm files and generated scripts for benchmark:", benchmark)
-    else:
-        raise ValueError("Error: Invalid arguments. Use --help for usage instructions.")
+    build_benchmarks()
+    for benchmark in config["BENCHMARKS_FIBER_C"]:
+        generate_scripts(benchmark,args.engines)
+        print("Generated scripts for benchmark:", benchmark)
 
 if __name__ == "__main__":
     main()

--- a/config.yml
+++ b/config.yml
@@ -1,44 +1,39 @@
-PREFIX : "#!/bin/bash\n"
-
 # List of valid engines
 ENGINES : [ "d8", "wasmtime", "wizard" ]
 
-# Paths to engines
+# Paths to engines and engine-specific options
+# Wasmtime
 WASMTIME_PATH : "/opt/wasmfx/wasmfxtime/target/release/wasmtime"
+WASMTIME_OPTIONS : "run --allow-precompiled -W=exceptions,function-references,gc,stack-switching"
+
+# V8
 D8_PATH : "/opt/wasmfx/v8/v8/out/x64.release/d8"
+D8_OPTIONS : "--experimental-wasm-wasmfx load.mjs --"
+
+# Wizard
 WIZARD_PATH : "/opt/wasmfx/wizard-engine/bin/wizeng.x86-64-linux"
-WIZARD_FLAGS : "--ext:stack-switching --ext:gc --ext:exception-handling --ext:function-references --stack-size=2097152"
-
-# Paths for building benchmarks
-ASYNCIFY_DEFAULT_STACK_SIZE: 2097152
-STACK_POOL_SIZE: 0
-WASMFX_CONT_TABLE_INITIAL_CAPACITY: 1024
-WASMFX_PRESERVE_SHADOW_STACK: 1
-WASMFX_CONT_SHADOW_STACK_SIZE: 65536
-ASYNCIFY : "/opt/wasmfx/binaryen/bin/wasm-opt --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 --asyncify"
-WASICC : "/opt/wasmfx/wasi-sdk/build/install/bin/clang"
-WASIFLAGS : "--sysroot=/opt/wasmfx/wasi-sdk/build/install/share/wasi-sysroot -std=c17 -Wall -Wextra -Werror -Wpedantic -Wno-strict-prototypes  -O3 -I inc"
-WASM_INTERP : "/opt/wasmfx/specfx/interpreter/wasm"
-WASM_MERGE : "/opt/wasmfx/binaryen/bin/wasm-merge --enable-multimemory --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching --enable-nontrapping-float-to-int"
-SHADOW_STACK_FLAG : ""
-
-# Paths to imports
-WASMFX_IMPORTS : "wasmfx_imports.wasm"
-V8_JS_LOADER : "load.mjs"
+WIZARD_OPTIONS : "--ext:stack-switching --ext:gc --stack-size=65536 --mode=jit"
 
 # List of benchmarks
-# it's called `sieve1` because there is a different benchmark also called `sieve` in benchfx
 BENCHMARKS_FIBER_C : [
-    "c10m",
     "itersum",
-    "pi",
-    "sieve1",
-    "skynet",
+    "sieve",
     "state",
-    "treesum"
+    "treesum",
+    #"treesumlinear",
+    "c10m",
+    "pi",
+    "skynet",
   ]
 
 # Arguments for benchmarks
 ITERSUM_ARGS : 1000000
 TREESUM_ARGS : 25
-SIEVE1_ARGS : 2000
+SIEVE_ARGS : 2000
+
+# Wasmtime stack pool sizes for benchmarks that may do better with a different number from the default 1024 stacks
+WASMTIME_STACK_POOL_SIZES : {
+    "c10m": 10000,
+    "sieve": 2000, # this needs to be equal to SIEVE_ARGS
+    "skynet" : 6,
+}


### PR DESCRIPTION
- Refactored build.py so that it just calls the makefile and generates the benchmarking scripts. Maybe it should be renamed to something more appropriate like "gen-scripts.py"?
- Added support for running benchmarks on wasmfxtime with an appropriate `total-stacks` argument stored in `config.yml`. The most up-to-date version of this repo is actually broken because it didn't have this.
- Deleted some useless arguments from both build.py and bench.py, usage should be a lot simpler now, e.g. `./bench.py` should be all you need to do to build and run all the benchmarks, `./build.py` is all you need to do to generate benchmarking scripts for everything.