### PR TITLE
Updated dependencies in Makefile/config for switch rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,16 @@ out/%_asyncify.wasm: examples/%.c inc/fiber.h src/asyncify/asyncify_impl.c | out
 	$(ASYNCIFY) $(@:.wasm=.pre.wasm) -o $@
 	chmod +x $@
 
+out/%_switch_asyncify.wasm: examples/%_switch.c inc/fiber_switch.h src/asyncify/asyncify_impl.c | out
+	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_switch_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
+	$(ASYNCIFY) $(@:.wasm=.pre.wasm) -o $@
+	chmod +x $@
+
 fiber_wasmfx_imports.wasm: src/wasmfx/imports.wat
 	$(WASM_INTERP) -d -i $< -o $@
+
+fiber_switch_wasmfx_imports.wasm: src/wasmfx/imports_switch.wat
+	$(WASM_INTERP_SWITCH) -d -i src/wasmfx/imports_switch.wat -o fiber_switch_wasmfx_imports.wasm
 
 out/%_wasmfx.unopt.wasm: examples/%.c inc/fiber.h src/wasmfx/imports.wat src/wasmfx/wasmfx_impl.c fiber_wasmfx_imports.wasm | out
 	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
@@ -39,26 +47,16 @@ out/%_wasmfx.wasm: out/%_wasmfx.unopt.wasm
 	$(WASM_OPT) $< -o $@
 	chmod +x $@
 
+out/%_switch_wasmfx.wasm: examples/%_switch.c inc/fiber_switch.h src/wasmfx/imports_switch.wat src/wasmfx/wasmfx_switch_impl.c fiber_switch_wasmfx_imports.wasm | out
+	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_switch_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
+	$(WASM_MERGE) fiber_switch_wasmfx_imports.wasm "fiber_switch_wasmfx_imports" $(@:.wasm=.pre.wasm) "main" -o $@
+	chmod +x $@
+
 out/%.cwasm: out/%.wasm
 	$(WASMTIME) compile -W=exceptions,function-references,gc,stack-switching -O opt-level=2 $< -o $@
 
 src/wasmfx/imports.wat: src/wasmfx/imports.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports.wat
-
-# Switch rules
-
-out/%_switch_asyncify.wasm: examples/%_switch.c inc/fiber_switch.h src/asyncify/asyncify_impl.c | out
-	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_switch_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
-	$(ASYNCIFY) $(@:.wasm=.pre.wasm) -o $@
-	chmod +x $@
-
-fiber_switch_wasmfx_imports.wasm: src/wasmfx/imports_switch.wat
-	$(WASM_INTERP_SWITCH) -d -i src/wasmfx/imports_switch.wat -o fiber_switch_wasmfx_imports.wasm
-
-out/%_switch_wasmfx.wasm: examples/%_switch.c inc/fiber_switch.h src/wasmfx/imports_switch.wat src/wasmfx/wasmfx_switch_impl.c fiber_switch_wasmfx_imports.wasm | out
-	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_switch_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
-	$(WASM_MERGE) fiber_switch_wasmfx_imports.wasm "fiber_switch_wasmfx_imports" $(@:.wasm=.pre.wasm) "main" -o $@
-	chmod +x $@
 
 src/wasmfx/imports_switch.wat: src/wasmfx/imports_switch.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports_switch.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports_switch.wat

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,23 @@ else
 endif
 
 .PHONY: all
-BENCHMARKS=c10m hello itersum pi sieve simple skynet state treesum treesumlinear
-# treesum_switch itersum_switch hello_switch
+BENCHMARKS= hello c10m hello itersum pi sieve skynet state treesum treesumlinear
+SWITCH_BENCHMARKS= hello itersum treesum
 
 # This strange invocation tells make not to delete "intermediate products".
 .SECONDARY:
 
-all: $(BENCHMARKS)
+all: $(BENCHMARKS) $(SWITCH_BENCHMARKS)
 
 %: out/%_asyncify.wasm out/%_wasmfx.wasm out/%_asyncify.cwasm out/%_wasmfx.cwasm
 	@echo Made $@ #from $^
+
+$(SWITCH_BENCHMARKS): %: out/%_switch_asyncify.wasm out/%_switch_wasmfx.wasm
 
 out/%_asyncify.wasm: examples/%.c inc/fiber.h src/asyncify/asyncify_impl.c | out
 	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
 	$(ASYNCIFY) $(@:.wasm=.pre.wasm) -o $@
 	chmod +x $@
-
-fiber_switch_wasmfx_imports.wasm: src/wasmfx/imports_switch.wat
-	$(WASM_INTERP) -d -i src/wasmfx/imports_switch.wat -o fiber_switch_wasmfx_imports.wasm
 
 fiber_wasmfx_imports.wasm: src/wasmfx/imports.wat
 	$(WASM_INTERP) -d -i $< -o $@
@@ -40,16 +39,26 @@ out/%_wasmfx.wasm: out/%_wasmfx.unopt.wasm
 	$(WASM_OPT) $< -o $@
 	chmod +x $@
 
-out/%_switch_wasmfx.wasm: examples/%.c inc/fiber.h src/wasmfx/imports.wat src/wasmfx/wasmfx_impl.c fiber_switch_wasmfx_imports.wasm | out
-	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
-	$(WASM_MERGE) fiber_switch_wasmfx_imports.wasm "fiber_switch_wasmfx_imports" $(@:.wasm=.pre.wasm) "main" -o $@
-	chmod +x $@
-
 out/%.cwasm: out/%.wasm
 	$(WASMTIME) compile -W=exceptions,function-references,gc,stack-switching -O opt-level=2 $< -o $@
 
 src/wasmfx/imports.wat: src/wasmfx/imports.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports.wat
+
+# Switch rules
+
+out/%_switch_asyncify.wasm: examples/%_switch.c inc/fiber_switch.h src/asyncify/asyncify_impl.c | out
+	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_switch_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
+	$(ASYNCIFY) $(@:.wasm=.pre.wasm) -o $@
+	chmod +x $@
+
+fiber_switch_wasmfx_imports.wasm: src/wasmfx/imports_switch.wat
+	$(WASM_INTERP_SWITCH) -d -i src/wasmfx/imports_switch.wat -o fiber_switch_wasmfx_imports.wasm
+
+out/%_switch_wasmfx.wasm: examples/%_switch.c inc/fiber_switch.h src/wasmfx/imports_switch.wat src/wasmfx/wasmfx_switch_impl.c fiber_switch_wasmfx_imports.wasm | out
+	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_switch_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)
+	$(WASM_MERGE) fiber_switch_wasmfx_imports.wasm "fiber_switch_wasmfx_imports" $(@:.wasm=.pre.wasm) "main" -o $@
+	chmod +x $@
 
 src/wasmfx/imports_switch.wat: src/wasmfx/imports_switch.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports_switch.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports_switch.wat

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ fiber_wasmfx_imports.wasm: src/wasmfx/imports.wat
 	$(WASM_INTERP) -d -i $< -o $@
 
 fiber_switch_wasmfx_imports.wasm: src/wasmfx/imports_switch.wat
-	$(WASM_INTERP_SWITCH) -d -i src/wasmfx/imports_switch.wat -o fiber_switch_wasmfx_imports.wasm
+	$(WASM_INTERP) -d -i src/wasmfx/imports_switch.wat -o fiber_switch_wasmfx_imports.wasm
 
 out/%_wasmfx.unopt.wasm: examples/%.c inc/fiber.h src/wasmfx/imports.wat src/wasmfx/wasmfx_impl.c fiber_wasmfx_imports.wasm | out
 	$(WASICC) $(SHADOW_STACK_FLAG) -DWASMFX_CONT_SHADOW_STACK_SIZE=$(WASMFX_CONT_SHADOW_STACK_SIZE) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -Wl,--export-table,--export-memory,--export=__stack_pointer src/wasmfx/wasmfx_impl.c $(WASIFLAGS) $< -o $(@:.wasm=.pre.wasm)

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ WASMTIME_PATH : "/opt/wasmfx/wasmfxtime/target/release/wasmtime"
 WASMTIME_OPTIONS : "run --allow-precompiled -W=exceptions,function-references,gc,stack-switching"
 
 # V8
-D8_PATH : "/opt/wasmfx/v8/v8/out/x64.release/d8"
+D8_PATH : "/opt/wasmfx/v8/out/x64.release/d8"
 D8_OPTIONS : "--experimental-wasm-wasmfx load.mjs --"
 
 # Wizard

--- a/make.config
+++ b/make.config
@@ -15,5 +15,4 @@ WASM_MERGE=$(BINARYEN)/bin/wasm-merge --enable-nontrapping-float-to-int --enable
 WASMTIME?=/opt/wasmfx/wasmfxtime/target/release/wasmtime
 
 # Switch-specific dependencies
-WASM_INTERP_SWITCH?=/opt/wasmfx/stack-switching/interpreter/wasm
 WASMTIME_SWITCH?=/opt/wasmfx/wasmtime/target/release/wasmtime

--- a/make.config
+++ b/make.config
@@ -4,16 +4,16 @@ WASMFX_CONT_TABLE_INITIAL_CAPACITY?=1024
 WASMFX_PRESERVE_SHADOW_STACK?=1
 # Only relevant if WASMFX_PRESERVE_SHADOW_STACK is 1
 WASMFX_CONT_SHADOW_STACK_SIZE?=65536
-BINARYEN?=/opt/wasmfx/binaryenfx
+BINARYEN?=/opt/wasmfx/binaryen
 ASYNCIFY=$(BINARYEN)/bin/wasm-opt --enable-nontrapping-float-to-int --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 --asyncify -g
 WASM_OPT=$(BINARYEN)/bin/wasm-opt --enable-nontrapping-float-to-int --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 -g
-# TODO: fix this
-WASI_SDK?=../../wasi-sdk-22.0
+WASI_SDK?=../../wasi-sdk-30.0-x86_64-linux
 WASICC=$(WASI_SDK)/bin/clang
 WASIFLAGS=--sysroot=$(WASI_SDK)/share/wasi-sysroot -std=c17 -Wall -Wextra -Werror -Wpedantic -Wno-strict-prototypes -O3 -I inc
-# WASICC=/opt/wasmfx/wasi-sdk/build/install/bin/clang
-# WASIFLAGS=--sysroot=/opt/wasmfx/wasi-sdk/build/install/share/wasi-sysroot -std=c17 -Wall -Wextra -Werror -Wpedantic -Wno-strict-prototypes  -O3 -I inc
-WASM_INTERP?=/opt/wasmfx/specfx/interpreter/wasm
+WASM_INTERP?=/opt/wasmfx/stack-switching/interpreter/wasm
 WASM_MERGE=$(BINARYEN)/bin/wasm-merge --enable-nontrapping-float-to-int --enable-multimemory --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching
-# WASMTIME=/opt/wasmfx/wasmtime/target/release/wasmtime
 WASMTIME?=/opt/wasmfx/wasmfxtime/target/release/wasmtime
+
+# Switch-specific dependencies
+WASM_INTERP_SWITCH?=/opt/wasmfx/stack-switching/interpreter/wasm
+WASMTIME_SWITCH?=/opt/wasmfx/wasmtime/target/release/wasmtime


### PR DESCRIPTION
The existing make rules for the switch programs don't work. Also shuffled the rules around a little bit so it's easier to tell which ones are switch-specific.