### PR TITLE
Make the root of all the software customizable

### DIFF
--- a/make.config
+++ b/make.config
@@ -9,7 +9,8 @@ ROOT?=/opt/wasmfx
 BINARYEN?=$(ROOT)/binaryen
 ASYNCIFY=$(BINARYEN)/bin/wasm-opt --enable-nontrapping-float-to-int --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 --asyncify -g
 WASM_OPT=$(BINARYEN)/bin/wasm-opt --enable-nontrapping-float-to-int --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 -g
-WASI_SDK?=$(ROOT)/wasi-sdk-30.0-x86_64-linux
+# A crude way to select whatever version of wasi-sdk is there at $ROOT.
+WASI_SDK?=$(shell ls -d $(ROOT)/wasi-sdk-*-linux)
 WASICC=$(WASI_SDK)/bin/clang
 WASIFLAGS=--sysroot=$(WASI_SDK)/share/wasi-sysroot -std=c17 -Wall -Wextra -Werror -Wpedantic -Wno-strict-prototypes -O3 -I inc
 WASM_INTERP?=$(ROOT)/stack-switching/interpreter/wasm

--- a/make.config
+++ b/make.config
@@ -4,15 +4,17 @@ WASMFX_CONT_TABLE_INITIAL_CAPACITY?=1024
 WASMFX_PRESERVE_SHADOW_STACK?=1
 # Only relevant if WASMFX_PRESERVE_SHADOW_STACK is 1
 WASMFX_CONT_SHADOW_STACK_SIZE?=65536
-BINARYEN?=/opt/wasmfx/binaryen
+
+ROOT?=/opt/wasmfx
+BINARYEN?=$(ROOT)/binaryen
 ASYNCIFY=$(BINARYEN)/bin/wasm-opt --enable-nontrapping-float-to-int --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 --asyncify -g
 WASM_OPT=$(BINARYEN)/bin/wasm-opt --enable-nontrapping-float-to-int --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching -O2 -g
-WASI_SDK?=../../wasi-sdk-30.0-x86_64-linux
+WASI_SDK?=$(ROOT)/wasi-sdk-30.0-x86_64-linux
 WASICC=$(WASI_SDK)/bin/clang
 WASIFLAGS=--sysroot=$(WASI_SDK)/share/wasi-sysroot -std=c17 -Wall -Wextra -Werror -Wpedantic -Wno-strict-prototypes -O3 -I inc
-WASM_INTERP?=/opt/wasmfx/stack-switching/interpreter/wasm
+WASM_INTERP?=$(ROOT)/stack-switching/interpreter/wasm
 WASM_MERGE=$(BINARYEN)/bin/wasm-merge --enable-nontrapping-float-to-int --enable-multimemory --enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-stack-switching
-WASMTIME?=/opt/wasmfx/wasmfxtime/target/release/wasmtime
+WASMTIME?=$(ROOT)/wasmfxtime/target/release/wasmtime
 
 # Switch-specific dependencies
-WASMTIME_SWITCH?=/opt/wasmfx/wasmtime/target/release/wasmtime
+WASMTIME_SWITCH?=$(ROOT)/wasmtime/target/release/wasmtime


### PR DESCRIPTION
In the unique build on the ehop machine, it wants to be /opt/wasmfx but in the container it is presently /

(We _could_ change the container to put everything at /opt/wasmfx in the container fs...)