### PR TITLE
Update plotting scripts to make all the charts that are now on the webserver

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -34,7 +34,11 @@ def get_binary_sizes(benchmarks,filename, path):
     for benchmark in benchmarks:
         wasmfx_size = os.path.getsize(f"out/{benchmark}_wasmfx.wasm")
         asyncify_size = os.path.getsize(f"out/{benchmark}_asyncify.wasm")
-        entry = [ wasmfx_size, asyncify_size ]
+        entry = {
+            "benchmark": benchmark,
+            "wasmfx": wasmfx_size,
+            "asyncify": asyncify_size,
+            }
         data.append(entry)
     with open(f"bench_results/{path}/{filename}.json", "w") as f:
         json.dump(data,f)

--- a/bench.py
+++ b/bench.py
@@ -29,15 +29,12 @@ def run_benchmarks(benchmarks, engines, filename):
     subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_asyncify.json", "--export-csv", f"bench_results/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
 
 def get_binary_sizes(benchmarks,filename):
-    data={}
+    data=[]
     for benchmark in benchmarks:
         wasmfx_size = os.path.getsize(f"out/{benchmark}_wasmfx.wasm")
         asyncify_size = os.path.getsize(f"out/{benchmark}_asyncify.wasm")
-        entry = {
-            "wasmfx": wasmfx_size,
-            "asyncify": asyncify_size
-        }
-        data[benchmark] = entry
+        entry = [ wasmfx_size, asyncify_size ]
+        data.append(entry)
     with open(f"bench_results/{filename}.json", "w") as f:
         json.dump(data,f)
 
@@ -65,10 +62,13 @@ def main():
     # build and run everything
     call_buildscript()
     os.makedirs("bench_results", exist_ok=True)
+    os.makedirs("bench_results/charts", exist_ok=True)
     get_binary_sizes(args.benchmarks,f"{args.output}_binary_sizes")
     run_benchmarks(args.benchmarks, args.engines, args.output)
-     # make chart
-    os.system(f"python3 plot_benchmarks.py bench_results/{args.output}_wasmfx.json bench_results/{args.output}_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{args.output}")
+    # make binary size chart
+    os.system(f"python3 plot_binary_sizes.py bench_results/{args.output}_binary_sizes.json --benchmarks {' '.join(args.benchmarks)} -o bench_results/charts/{args.output}")
+    # make runtime chart
+    os.system(f"python3 plot_benchmarks.py bench_results/{args.output}_wasmfx.json bench_results/{args.output}_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/charts/{args.output}")
     # clean up .wasm files and scripts
     subprocess.check_call(["make", "clean"])
 

--- a/bench.py
+++ b/bench.py
@@ -25,7 +25,7 @@ def call_buildscript():
     
 def run_benchmarks(benchmarks, engines, filename, path):
     # call hyperfine to run wasmfx benchmarks
-    subprocess.check_call (["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_wasmfx.json", "--export-csv", f"bench_results/{path}/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
+    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_wasmfx.json", "--export-csv", f"bench_results/{path}/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
     # and now asyncify benchmarks
     subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_asyncify.json", "--export-csv", f"bench_results/{path}/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
 
@@ -64,8 +64,12 @@ def main():
 
     # build and run everything
     call_buildscript()
+    # make nice output directories
     os.makedirs(f"bench_results/{path}", exist_ok=True)
-    os.makedirs(f"bench_results/{path}/charts", exist_ok=True)
+    os.makedirs(f"bench_results/{path}/charts/absolute_benchmarks", exist_ok=True)
+    os.makedirs(f"bench_results/{path}/charts/absolute_engines", exist_ok=True)
+    os.makedirs(f"bench_results/{path}/charts/relative", exist_ok=True)
+    # get all the data we want
     get_binary_sizes(args.benchmarks,"binary_sizes", path)
     run_benchmarks(args.benchmarks, args.engines, "results", path)
     # make binary size chart

--- a/bench.py
+++ b/bench.py
@@ -3,7 +3,8 @@
 Script that calls buildscript and runs fiber-c benchmarks.
 Usage:  `./bench.py --help`
         `./bench.py` # runs all benchmarks on all engines by default
-        `./bench.py --benchmarks sieve1 itersum --engines d8 wasmtime`
+        `./bench.py --benchmarks sieve1 itersum --engines d8 wasmtime -o results_dir` 
+            # runs selected benchmarks and engines, saves results to `bench_results/results_dir`
 """
 import argparse
 import yaml
@@ -22,20 +23,20 @@ all_engines = config["ENGINES"]
 def call_buildscript():
     subprocess.check_call(["./build.py"])
     
-def run_benchmarks(benchmarks, engines, filename):
+def run_benchmarks(benchmarks, engines, filename, path):
     # call hyperfine to run wasmfx benchmarks
-    subprocess.check_call (["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_wasmfx.json", "--export-csv", f"bench_results/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
+    subprocess.check_call (["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_wasmfx.json", "--export-csv", f"bench_results/{path}/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
     # and now asyncify benchmarks
-    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_asyncify.json", "--export-csv", f"bench_results/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
+    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_asyncify.json", "--export-csv", f"bench_results/{path}/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
 
-def get_binary_sizes(benchmarks,filename):
+def get_binary_sizes(benchmarks,filename, path):
     data=[]
     for benchmark in benchmarks:
         wasmfx_size = os.path.getsize(f"out/{benchmark}_wasmfx.wasm")
         asyncify_size = os.path.getsize(f"out/{benchmark}_asyncify.wasm")
         entry = [ wasmfx_size, asyncify_size ]
         data.append(entry)
-    with open(f"bench_results/{filename}.json", "w") as f:
+    with open(f"bench_results/{path}/{filename}.json", "w") as f:
         json.dump(data,f)
 
 def main():
@@ -48,7 +49,7 @@ def main():
         "--engines", nargs="*", help="List of engines to run (d8, wasmtime, wizard)", 
         default=all_engines
     )
-    parser.add_argument("--output", "-o", help="Filename to save results to. Default is `results`, such that is output live in bench_results/results_{backend}",
+    parser.add_argument("--output", "-o", help="Subdirectory to save results to. Default is `results`, e.g. bench_results/results",
         default=f"results"
     )
     args = parser.parse_args()
@@ -58,17 +59,19 @@ def main():
 
     if not set(args.engines).issubset(set(all_engines)):
         raise ValueError(f"Error: invalid engine name(s). Valid options are: {', '.join(all_engines)}")
+    
+    path = args.output
 
     # build and run everything
     call_buildscript()
-    os.makedirs("bench_results", exist_ok=True)
-    os.makedirs("bench_results/charts", exist_ok=True)
-    get_binary_sizes(args.benchmarks,f"{args.output}_binary_sizes")
-    run_benchmarks(args.benchmarks, args.engines, args.output)
+    os.makedirs(f"bench_results/{path}", exist_ok=True)
+    os.makedirs(f"bench_results/{path}/charts", exist_ok=True)
+    get_binary_sizes(args.benchmarks,"binary_sizes", path)
+    run_benchmarks(args.benchmarks, args.engines, "results", path)
     # make binary size chart
-    os.system(f"python3 plot_binary_sizes.py bench_results/{args.output}_binary_sizes.json --benchmarks {' '.join(args.benchmarks)} -o bench_results/charts/{args.output}")
+    os.system(f"python3 plot_binary_sizes.py bench_results/{path}/binary_sizes.json --benchmarks {' '.join(args.benchmarks)} -o bench_results/{path}/charts")
     # make runtime chart
-    os.system(f"python3 plot_benchmarks.py bench_results/{args.output}_wasmfx.json bench_results/{args.output}_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/charts/{args.output}")
+    os.system(f"python3 plot_benchmarks.py bench_results/{path}/results_wasmfx.json bench_results/{path}/results_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts")
     # clean up .wasm files and scripts
     subprocess.check_call(["make", "clean"])
 

--- a/bench.py
+++ b/bench.py
@@ -21,11 +21,11 @@ all_engines = config["ENGINES"]
 def call_buildscript():
     subprocess.check_call(["./build.py"])
     
-def run_benchmarks(benchmarks, engines):
+def run_benchmarks(benchmarks, engines, filename):
     # call hyperfine to run wasmfx benchmarks
-    subprocess.check_call (["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", "bench_results/wasmfx_results.json", "--export-csv", "bench_results/wasmfx_results.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
+    subprocess.check_call (["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_wasmfx.json", "--export-csv", f"bench_results/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
     # and now asyncify benchmarks
-    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", "bench_results/asyncify_results.json", "--export-csv", "bench_results/asyncify_results.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
+    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_asyncify.json", "--export-csv", f"bench_results/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -36,6 +36,9 @@ def main():
     parser.add_argument(
         "--engines", nargs="*", help="List of engines to run (d8, wasmtime, wizard)", 
         default=all_engines
+    )
+    parser.add_argument("--output", "-o", help="Filename to save results to. Default is `results`, such that is output live in bench_results/results_{backend}",
+        default=f"results"
     )
     args = parser.parse_args()
 
@@ -48,15 +51,11 @@ def main():
     # build and run everything
     call_buildscript()
     os.makedirs("bench_results", exist_ok=True)
-    run_benchmarks(args.benchmarks, args.engines)
-
+    run_benchmarks(args.benchmarks, args.engines, args.output)
      # make chart
-    os.system(f"python3 plot_benchmarks.py bench_results/wasmfx_results.json bench_results/asyncify_results.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/results")
-    # make a copy of the chart in the root directory of ehop machine for webserver reasons
-    shutil.copytree("bench_results", "/opt/wasmfx/bench_results_page", dirs_exist_ok=True)
+    os.system(f"python3 plot_benchmarks.py bench_results/{args.output}_wasmfx.json bench_results/{args.output}_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{args.output}")
     # clean up .wasm files and scripts
     subprocess.check_call(["make", "clean"])
 
 if __name__ == "__main__":
     main()
-    

--- a/bench.py
+++ b/bench.py
@@ -11,6 +11,7 @@ import sys
 import os
 import subprocess
 import shutil
+import json
 from pathlib import Path
 
 config = yaml.safe_load(open("config.yml"))
@@ -26,6 +27,19 @@ def run_benchmarks(benchmarks, engines, filename):
     subprocess.check_call (["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_wasmfx.json", "--export-csv", f"bench_results/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
     # and now asyncify benchmarks
     subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{filename}_asyncify.json", "--export-csv", f"bench_results/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
+
+def get_binary_sizes(benchmarks,filename):
+    data={}
+    for benchmark in benchmarks:
+        wasmfx_size = os.path.getsize(f"out/{benchmark}_wasmfx.wasm")
+        asyncify_size = os.path.getsize(f"out/{benchmark}_asyncify.wasm")
+        entry = {
+            "wasmfx": wasmfx_size,
+            "asyncify": asyncify_size
+        }
+        data[benchmark] = entry
+    with open(f"bench_results/{filename}.json", "w") as f:
+        json.dump(data,f)
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -51,6 +65,7 @@ def main():
     # build and run everything
     call_buildscript()
     os.makedirs("bench_results", exist_ok=True)
+    get_binary_sizes(args.benchmarks,f"{args.output}_binary_sizes")
     run_benchmarks(args.benchmarks, args.engines, args.output)
      # make chart
     os.system(f"python3 plot_benchmarks.py bench_results/{args.output}_wasmfx.json bench_results/{args.output}_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{args.output}")

--- a/config.yml
+++ b/config.yml
@@ -24,16 +24,21 @@ BENCHMARKS_FIBER_C : [
     "c10m",
     "pi",
     "skynet",
+    "itersum_switch",
+    "treesum_switch",
   ]
 
 # Arguments for benchmarks
 ITERSUM_ARGS : 1000000
 TREESUM_ARGS : 25
 SIEVE_ARGS : 2000
+ITERSUM_SWITCH_ARGS : 1000000
+TREESUM_SWITCH_ARGS : 25
 
 # Wasmtime stack pool sizes for benchmarks that may do better with a different number from the default 1024 stacks
 WASMTIME_STACK_POOL_SIZES : {
     "c10m": 10000,
     "sieve": 2000, # this needs to be equal to SIEVE_ARGS
     "skynet" : 6,
+    "itersum" : 1,
 }

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -11,6 +11,13 @@
 Script that generates:
     1. A bar chart displaying the relative performance of asyncify and wasmfx benchmarks, grouped by engine
     2. $number_of_engines$ bar charts displaying the raw runtime/binary size/etc data for each engine
+    3. $number_of_benchmarks$ bar charts displaying the raw runtime/binary size/etc data for each benchmark
+
+Where
+    (1) is saved in results_dir/relative/relative.png, 
+    (2) is saved in results_dir/absolute_engines/absolute_{engine}.png, 
+    (3) is saved in results_dir/absolute_benchmarks/absolute_{benchmark}.png
+
 Usage: 
     `python3 plot_benchmarks.py results_wasmfx.json results_asyncify.json --benchmarks itersum --engines wasmtime d8 -o results_dir`
 """
@@ -95,12 +102,12 @@ plt.axhline(
 
 # Export figure
 if args.output:
-    plt.savefig(f"{args.output}/relative", bbox_inches="tight")
+    plt.savefig(f"{args.output}/relative/relative", bbox_inches="tight")
 else:
     plt.show()
 
 # --------------
-# ----- Next 3 (or rather, len(engines)) charts: absolute times for asyncify and wasmfx for each benchmark, per engine -----
+# ----- Next 3 (or rather, len(engines)) charts: absolute times for asyncify and wasmfx for each benchmark, grouped by engine -----
 # --------------
 
 # We want a different chart for each engine where bars are grouped by benchmarks, 
@@ -124,7 +131,6 @@ for i, engine in enumerate(engines):
     ax.set_xticks(bar_loc, axis_labels)
 
     # Keeps every other label, make the rest invisible
-    n = len(benches)
     [l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if (i+1) % 2 == 0]
 
     # Readability features
@@ -136,6 +142,49 @@ for i, engine in enumerate(engines):
 
     # Export figure
     if args.output:
-        plt.savefig(f"{args.output}/absolute_{engine}", bbox_inches="tight")
+        plt.savefig(f"{args.output}/absolute_engines/absolute_{engine}", bbox_inches="tight")
+    else:
+        plt.show()
+
+# --------------
+# ----- Next n (or rather, len(benches)) charts: absolute times for asyncify and wasmfx, grouped by benchmark -----
+# --------------
+
+# Now we want a different chart for each benchmark where bars are grouped by engines
+for i, benchmark in enumerate(benches):
+    # Get array of data from this benchmark
+    # There should always be 2 * len(engines) entries for each benchmark
+    bench_data = []
+    for j in range(len(engines)):
+        bench_data.append(data[i + j*len(benches)][0]) # wasmfx time for this benchmark and engine
+        bench_data.append(data[i + j*len(benches)][1]) # asyncify time for this benchmark and engine
+    
+    # Set x values for bar locations, with one group of (two) bars for each benchmark
+    # This is the same as the previous chart except we have len(engines) groups of bars
+    bar_loc = [x for x in np.arange(len(engines) * 3) if ((x+1) % 3) != 0]
+
+    # Plot data
+    fig, ax = plt.subplots()
+    for i in range(len(bench_data)):
+        ax.bar(bar_loc[i], bench_data[i], width, label=engines[i % len(engines)], color=bar_colors[i % 2])
+    
+    # Pad out list of benchmarks to match number of engines
+    axis_labels = np.repeat(engines, 2)
+    ax.set_xticks(bar_loc, axis_labels)
+
+    # Keeps every other label, make the rest invisible
+    n = len(engines)
+    [l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if (i+1) % 2 == 0]
+
+    # Readability features
+    ax.grid(visible=True, axis="y")
+    plt.title(f"Benchmark results (absolute times) for {benchmark}")
+    plt.xlabel("Engine")
+    plt.ylabel("Time (seconds)")
+    plt.legend(['WasmFX', 'Asyncify'], bbox_to_anchor=(1.3, 1), loc="upper right")
+
+    # Export figure
+    if args.output:
+        plt.savefig(f"{args.output}/absolute_benchmarks/absolute_{benchmark}", bbox_inches="tight")
     else:
         plt.show()

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -70,34 +70,37 @@ x = [x for x in np.arange((len(benches) + 1) * len(engines)) if ((x+1) % (len(be
 width = 1
 bar_colors = ['tab:blue', 'tab:orange', 'tab:cyan', 'tab:red', 'tab:purple', 'tab:brown', 'tab:pink', 'tab:gray']
 
-fig, ax = plt.subplots()
+def make_chart(data, ratio_line:bool, title:str, xlabel:str, ylabel:str):
+    fig, ax = plt.subplots()
 
-for i in range(len(ratio)):
-    ax.bar(x[i], ratio[i], width, label=benches[i % len(benches)], color=bar_colors[i % len(benches)])
+    for i in range(len(data)):
+        ax.bar(x[i], data[i], width, label=benches[i % len(benches)], color=bar_colors[i % len(benches)])
 
-# pad out list of engines to match length of commands, so x-axis labels are engines
-axis_labels = np.repeat(engines, len(benches))
-ax.set_xticks(x, axis_labels)
+    # pad out list of engines to match length of commands, so x-axis labels are engines
+    axis_labels = np.repeat(engines, len(benches))
+    ax.set_xticks(x, axis_labels)
 
-# Keeps every nth label, make the rest invisible
-n = len(benches)
-[l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if i % n != math.ceil(n/2) - 1]
+    # Keeps every nth label, make the rest invisible
+    n = len(benches)
+    [l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if i % n != math.ceil(n/2) - 1]
 
-ax.grid(visible=True, axis="y")
-plt.title("Benchmark results (Asyncify time / WasmFX time)")
-plt.xlabel("Engine")
-plt.ylabel("Speedup (relative to Asyncify)")
-plt.legend(benches, bbox_to_anchor=(1.3, 1), loc="upper right")
-# TODO: make it display the label
-plt.axhline(
-  y=1.0, 
-  color = 'r',
-  linestyle = '--', 
-  linewidth = 3,
-  label = 'WasmFX = Asyncify'
-)
+    ax.grid(visible=True, axis="y")
+    plt.title(title)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.legend(benches, bbox_to_anchor=(1.3, 1), loc="upper right")
+    if (ratio_line):
+        # add a horizontal line at y=1 to indicate where wasmfx and asyncify are equal
+        plt.axhline(
+            y=1.0, 
+            color = 'r',
+            linestyle = '--', 
+            linewidth = 3,
+            label = 'WasmFX = Asyncify'
+            )
+    if args.output:
+        plt.savefig(f"{args.output}", bbox_inches="tight")
+    else:
+        plt.show()
 
-if args.output:
-    plt.savefig(f"{args.output}", bbox_inches="tight")
-else:
-    plt.show()
+make_chart(ratio, True, "Benchmark results (Asyncify time / WasmFX time)", "Engine", "Speedup (relative to Asyncify)" )

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -13,17 +13,14 @@ Script that generates:
     2. $number_of_engines$ bar charts displaying the raw runtime/binary size/etc data for each engine
 Usage: 
     `python3 plot_benchmarks.py results_wasmfx.json results_asyncify.json --benchmarks itersum --engines wasmtime d8 -o results_dir`
-    `todo: sample usage for making charts of binary sizes`
 """
+
 import argparse
 import json
 import pathlib
 import matplotlib.pyplot as plt
 import numpy as np
-import yaml
 import math
-
-config = yaml.safe_load(open("config.yml"))
 
 # deal with inputs
 parser = argparse.ArgumentParser(description=__doc__)
@@ -113,7 +110,9 @@ for i, engine in enumerate(engines):
     engine_data = data[(i)*(len(benches)):(i+1)*(len(benches))].flatten()
 
     # Set x values for bar locations, with one group of (two) bars for each benchmark
-    bar_loc = [x for x in np.arange((len(benches) + 1) * 2) if ((x+1) % 3) != 0]
+    # Logic: for each benchmark we allocate three bars, where the third one is a gap,
+    #   so we don't have multiples of 3 in our list of x-values.
+    bar_loc = [x for x in np.arange(len(benches) * 3) if ((x+1) % 3) != 0]
 
     # Plot data
     fig, ax = plt.subplots()
@@ -132,13 +131,11 @@ for i, engine in enumerate(engines):
     ax.grid(visible=True, axis="y")
     plt.title(f"Benchmark results (absolute times) for {engine}")
     plt.xlabel("Benchmark")
-    plt.ylabel("Time (milliseconds)")
+    plt.ylabel("Time (seconds)")
     plt.legend(['WasmFX', 'Asyncify'], bbox_to_anchor=(1.3, 1), loc="upper right")
 
     # Export figure
     if args.output:
-        plt.savefig(f"{args.output}_{engine}_absolute", bbox_inches="tight")
+        plt.savefig(f"{args.output}_absolute_{engine}", bbox_inches="tight")
     else:
         plt.show()
-
-# todo: binary sizes chart

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -8,8 +8,12 @@
 # ]
 # ///
 """
-Script that generates a bar chart comparing the results of asyncify and wasmfx benchmarks.
-Usage: `python3 plot_benchmarks.py wasmfx_results.json asyncify_results.json --benchmarks itersum --engines wasmtime d8 -o results_dir`
+Script that generates:
+    1. A bar chart displaying the relative performance of asyncify and wasmfx benchmarks, grouped by engine
+    2. $number_of_engines$ bar charts displaying the raw runtime/binary size/etc data for each engine
+Usage: 
+    `python3 plot_benchmarks.py results_wasmfx.json results_asyncify.json --benchmarks itersum --engines wasmtime d8 -o results_dir`
+    `todo: sample usage for making charts of binary sizes`
 """
 import argparse
 import json
@@ -20,87 +24,121 @@ import yaml
 import math
 
 config = yaml.safe_load(open("config.yml"))
-all_benchmarks = config["BENCHMARKS_FIBER_C"]
 
 # deal with inputs
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument(
-    "files", nargs="+", type=pathlib.Path, help="JSON files with benchmark results"
-)
-parser.add_argument(
-        "--benchmarks", nargs="*", help="List of benchmarks to run (sieve, itersum, treesum)", 
-        default=all_benchmarks
-    )
-parser.add_argument(
-        "--engines", nargs="*", help="List of engines to run (d8, wasmtime, wizard)", 
-        default=config["ENGINES"]
-    )
+parser.add_argument("files", nargs="+", type=pathlib.Path, help="JSON files with benchmark results")
+parser.add_argument("--benchmarks", nargs="*", help="List of benchmarks to run (sieve, itersum, treesum)")
+parser.add_argument("--engines", nargs="*", help="List of engines to run (d8, wasmtime, wizard)")
 parser.add_argument("-o", "--output", help="Save image to the given filename")
 
 args = parser.parse_args()
+benches = args.benchmarks
+engines = args.engines
 
-commands = None
+# Parse JSON files to extract benchmark results, we are only interested in the mean times
 data = []
 inputs = []
 
+# Make an array where each row corresponds to a benchmark/engine pair, each column corresponds to a backend (wasmfx vs asyncify), 
+# and the values are the mean runtimes from the hyperfine output json file
 for i, filename in enumerate(args.files):
     with open(filename) as f:
         results = json.load(f)["results"]
-    benchmark_commands = [b["command"] for b in results]
-    if commands is None:
-        commands = benchmark_commands
     data.append([round(b["mean"], 6) for b in results])
     inputs.append(filename.stem)
 
 data = np.transpose(data)
 
-# divide first column by second column to obtain wasmfx / asyncify ratio 
-# for each benchmark across all engines
-ratio = np.divide(data[:, 1], data[:, 0])
-
-benches = args.benchmarks
-engines = args.engines
-
-# x values for bar locations, with gaps between groups of bars for each engine#
-#   eg. x = [0,1,2,4,5,6,8,9,10] for 3 benchmarks across 3 engines, 
-#   with a gap of 1 between each group of 3 bars for each engine
-x = [x for x in np.arange((len(benches) + 1) * len(engines)) if ((x+1) % (len(benches) + 1)) != 0]
-
-# the width of the bars
+# The width of the bars in the chart
 width = 1
+# Hope this is colourblind-friendly enough for sam
 bar_colors = ['tab:blue', 'tab:orange', 'tab:cyan', 'tab:red', 'tab:purple', 'tab:brown', 'tab:pink', 'tab:gray']
 
-def make_chart(data, ratio_line:bool, title:str, xlabel:str, ylabel:str):
+# --------------
+# ------- First chart: ratio of asyncify time to wasmfx time for each benchmark across all engines -----
+# --------------
+
+# Get the chart data: divide first column by second column to obtain wasmfx / asyncify ratio
+ratio = np.divide(data[:, 1], data[:, 0])
+
+# Compute x values for bar locations, with gaps between groups of bars for each engine
+#   eg. x = [0,1,2,4,5,6,8,9,10] for 3 benchmarks across 3 engines, 
+#   with a gap of 1 between each group of 3 bars for each engine
+bar_loc = [x for x in np.arange((len(benches) + 1) * len(engines)) if ((x+1) % (len(benches) + 1)) != 0]
+
+# Plot the data
+fig, ax = plt.subplots()
+for i in range(len(ratio)):
+    ax.bar(bar_loc[i], ratio[i], width, label=benches[i % len(benches)], color=bar_colors[i % len(benches)])
+
+# Pad out list of engines to match number of benchmarks, so x-axis labels are engines
+axis_labels = np.repeat(engines, len(benches))
+ax.set_xticks(bar_loc, axis_labels)
+
+# Keeps every nth label, make the rest invisible
+n = len(benches)
+[l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if i % n != math.ceil(n/2) - 1]
+
+# Readability features
+ax.grid(visible=True, axis="y")
+plt.title("Benchmark results (Asyncify time / WasmFX time)")
+plt.xlabel("Engine")
+plt.ylabel("Speedup (relative to Asyncify)")
+plt.legend(benches, bbox_to_anchor=(1.3, 1), loc="upper right")
+
+# Add a horizontal line at y=1 to indicate where wasmfx and asyncify have equal performance
+plt.axhline(
+    y=1.0, 
+    color = 'r',
+    linestyle = '--', 
+    linewidth = 3,
+    label = 'WasmFX = Asyncify'
+    )
+
+# Export figure
+if args.output:
+    plt.savefig(f"{args.output}_relative", bbox_inches="tight")
+else:
+    plt.show()
+
+# --------------
+# ----- Next 3 (or rather, len(engines)) charts: absolute times for asyncify and wasmfx for each benchmark, per engine -----
+# --------------
+
+# We want a different chart for each engine where bars are grouped by benchmarks, 
+# and each bar corresponds to a different backend (wasmfx, asyncify).
+for i, engine in enumerate(engines):
+    # Get array of data from this engine
+    engine_data = data[(i)*(len(benches)):(i+1)*(len(benches))].flatten()
+
+    # Set x values for bar locations, with one group of (two) bars for each benchmark
+    bar_loc = [x for x in np.arange((len(benches) + 1) * 2) if ((x+1) % 3) != 0]
+
+    # Plot data
     fig, ax = plt.subplots()
+    for i in range(len(engine_data)):
+        ax.bar(bar_loc[i], engine_data[i], width, label=benches[i % len(benches)], color=bar_colors[i % 2])
 
-    for i in range(len(data)):
-        ax.bar(x[i], data[i], width, label=benches[i % len(benches)], color=bar_colors[i % len(benches)])
+    # Pad out list of engines to match number of benchmarks, so x-axis labels are engines
+    axis_labels = np.repeat(benches, 2)
+    ax.set_xticks(bar_loc, axis_labels)
 
-    # pad out list of engines to match length of commands, so x-axis labels are engines
-    axis_labels = np.repeat(engines, len(benches))
-    ax.set_xticks(x, axis_labels)
-
-    # Keeps every nth label, make the rest invisible
+    # Keeps every other label, make the rest invisible
     n = len(benches)
-    [l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if i % n != math.ceil(n/2) - 1]
+    [l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if (i+1) % 2 == 0]
 
+    # Readability features
     ax.grid(visible=True, axis="y")
-    plt.title(title)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
-    plt.legend(benches, bbox_to_anchor=(1.3, 1), loc="upper right")
-    if (ratio_line):
-        # add a horizontal line at y=1 to indicate where wasmfx and asyncify are equal
-        plt.axhline(
-            y=1.0, 
-            color = 'r',
-            linestyle = '--', 
-            linewidth = 3,
-            label = 'WasmFX = Asyncify'
-            )
+    plt.title(f"Benchmark results (absolute times) for {engine}")
+    plt.xlabel("Benchmark")
+    plt.ylabel("Time (milliseconds)")
+    plt.legend(['WasmFX', 'Asyncify'], bbox_to_anchor=(1.3, 1), loc="upper right")
+
+    # Export figure
     if args.output:
-        plt.savefig(f"{args.output}", bbox_inches="tight")
+        plt.savefig(f"{args.output}_{engine}_absolute", bbox_inches="tight")
     else:
         plt.show()
 
-make_chart(ratio, True, "Benchmark results (Asyncify time / WasmFX time)", "Engine", "Speedup (relative to Asyncify)" )
+# todo: binary sizes chart

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -95,7 +95,7 @@ plt.axhline(
 
 # Export figure
 if args.output:
-    plt.savefig(f"{args.output}_relative", bbox_inches="tight")
+    plt.savefig(f"{args.output}/relative", bbox_inches="tight")
 else:
     plt.show()
 
@@ -136,6 +136,6 @@ for i, engine in enumerate(engines):
 
     # Export figure
     if args.output:
-        plt.savefig(f"{args.output}_absolute_{engine}", bbox_inches="tight")
+        plt.savefig(f"{args.output}/absolute_{engine}", bbox_inches="tight")
     else:
         plt.show()

--- a/plot_binary_sizes.py
+++ b/plot_binary_sizes.py
@@ -69,6 +69,6 @@ plt.axhline(
 
 # Export figure
 if args.output:
-    plt.savefig(f"{args.output}_relative_binary_sizes", bbox_inches="tight")
+    plt.savefig(f"{args.output}/relative_binary_sizes", bbox_inches="tight")
 else:
     plt.show()

--- a/plot_binary_sizes.py
+++ b/plot_binary_sizes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "matplotlib",
+#     "pyqt6",
+#     "numpy",
+# ]
+# ///
+"""
+Script that generates a chart comparing the binary sizes of asyncify and wasmfx benchmarks.
+Usage: 
+    `python3 plot_binary_sizes.py results_binary_sizes.json --benchmarks itersum -o results_dir`
+"""
+
+import argparse
+import json
+import pathlib
+import matplotlib.pyplot as plt
+import numpy as np
+import math
+
+# deal with inputs
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--benchmarks", nargs="*", help="List of benchmarks to run (sieve, itersum, treesum)")
+parser.add_argument("files", type=pathlib.Path, help="JSON files with binary sizes")
+parser.add_argument("-o", "--output", help="Save image to the given filename")
+
+args = parser.parse_args()
+benches = args.benchmarks
+
+with open(args.files) as f:
+    data = json.load(f)
+
+data = np.array(data)
+
+# Get the chart data: divide first column by second column to obtain wasmfx / asyncify ratio
+ratio = np.divide(data[:, 1], data[:, 0])
+
+# The width of the bars in the chart
+width = 1
+
+# Hope this is colourblind-friendly enough for sam
+bar_colors = ['tab:blue', 'tab:orange', 'tab:cyan', 'tab:red', 'tab:purple', 'tab:brown', 'tab:pink', 'tab:gray']
+
+# x-values for bar locations
+bar_loc = np.arange(len(benches))
+
+# Plot the data
+fig, ax = plt.subplots()
+for i in range(len(ratio)):
+    ax.bar(bar_loc[i], ratio[i], width, label=benches[i], color=bar_colors[i])
+
+ax.set_xticks(bar_loc, benches)
+ax.grid(visible=True, axis="y")
+plt.title(f"Benchmark binary size comparison (Asyncify size / WasmFX size)")
+plt.xlabel("Benchmark")
+plt.ylabel("Size Ratio")
+plt.legend(benches, bbox_to_anchor=(1.3, 1), loc="upper right")
+
+# Add a horizontal line at y=1 to indicate where wasmfx and asyncify have equal performance
+plt.axhline(
+    y=1.0, 
+    color = 'r',
+    linestyle = '--', 
+    linewidth = 3,
+    label = 'WasmFX = Asyncify'
+    )
+
+# Export figure
+if args.output:
+    plt.savefig(f"{args.output}_relative_binary_sizes", bbox_inches="tight")
+else:
+    plt.show()

--- a/plot_binary_sizes.py
+++ b/plot_binary_sizes.py
@@ -69,6 +69,6 @@ plt.axhline(
 
 # Export figure
 if args.output:
-    plt.savefig(f"{args.output}/relative_binary_sizes", bbox_inches="tight")
+    plt.savefig(f"{args.output}/relative/relative_binary_sizes", bbox_inches="tight")
 else:
     plt.show()

--- a/plot_binary_sizes.py
+++ b/plot_binary_sizes.py
@@ -32,7 +32,10 @@ benches = args.benchmarks
 with open(args.files) as f:
     data = json.load(f)
 
-data = np.array(data)
+# The data should be a json of shape {"benchmark": str, "wasmfx": int, "asyncify": int}
+# We will now remove the "benchmark" field because we already have the benchmark names in the `benches` variable,
+# and stick the "wasmfx" and "asyncify" fields into a numpy array for easier manipulation
+data = np.array([[entry["wasmfx"], entry["asyncify"]] for entry in data])
 
 # Get the chart data: divide first column by second column to obtain wasmfx / asyncify ratio
 ratio = np.divide(data[:, 1], data[:, 0])


### PR DESCRIPTION
- `plot_benchmarks.py` now generates two sets of charts displaying raw runtimes, one set displays all data for a particular engine while the other displays all data for a particular benchmark across all engines.
- `plot_binary_sizes.py` has been added. 
- Output directory for hyperfine results and charts have been made nicer
- `bench.py` has been updated to reflect the changes above