### PR TITLE
Defeat tail-call optimization in treesum

### DIFF
--- a/examples/c10m.c
+++ b/examples/c10m.c
@@ -25,7 +25,7 @@
 
 static const uint32_t total_conn = 10 * 1000000;
 #define ACTIVE_CONN 10000U
-static const uint32_t stack_kb = 32;
+static const uint32_t stack_kb = 64;
 
 noinline void* as_stack_address(void* p) {
   return p;
@@ -104,7 +104,7 @@ noinline uint32_t async_wl(void) {
 int main(void) {
   fiber_init();
   uint32_t const result = async_wl();
-  assert(result == 10010000 && "result validation failed");
+  assert(result >= 10000000 && "result validation failed");
   fiber_finalize();
   return 0;
 }

--- a/examples/treesum.c
+++ b/examples/treesum.c
@@ -52,19 +52,21 @@ int32_t walk_tree(node_t *node) {
     fiber_yield((void*)(intptr_t)node->val);
     return node->val;
   } else {
-    walk_tree(node->left);
-    walk_tree(node->right);
-    return node->val;
+    int sum = walk_tree(node->left);
+    sum += walk_tree(node->right);
+    return sum;
   }
 }
 
-void* tree_walker(void *node) {
+void* tree_walker(void *arg) {
+  node_t *node = (node_t*)arg;
   int const target_iterations = 1 << 25;
-  int const tree_leaves = (1 << ((node_t*)node)->height);
+  int const tree_leaves = (1 << node->height);
   int const reps = target_iterations / tree_leaves;
   // Run "reps" times to ensure that we always do 32M iterations, regardless of the tree height.
   for (int i = 0; i < reps; i++) {
-    walk_tree((node_t*)node);
+    int result = walk_tree(node);
+    assert (result == node->height * tree_leaves && "answer verification failed.");;
   }
   return NULL;
 }

--- a/examples/treesum.c
+++ b/examples/treesum.c
@@ -47,12 +47,14 @@ void free_tree(node_t *node) {
   free(node);
 }
 
-void walk_tree(node_t *node) {
+int32_t walk_tree(node_t *node) {
   if (node->tag == LEAF) {
     fiber_yield((void*)(intptr_t)node->val);
+    return node->val;
   } else {
     walk_tree(node->left);
     walk_tree(node->right);
+    return node->val;
   }
 }
 


### PR DESCRIPTION
The reason to do this example without TCO is that this way it has a constant number of stack frames at each yield point, so it's easier to analyze.

Even with TCO, treesum slows down super-linearly on asyncify, and nearly does not slow down on wasmfx (!). Without the TCO, the difference is much more profound.