### PR TITLE
Callgraphs and stripped executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ src/wasmfx/imports.wat: src/wasmfx/imports.wat.pp
 src/wasmfx/imports_switch.wat: src/wasmfx/imports_switch.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports_switch.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports_switch.wat
 
-.PHONY: out
 out:
 	mkdir -p out
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SWITCH_BENCHMARKS= hello itersum treesum
 
 all: $(BENCHMARKS) $(SWITCH_BENCHMARKS)
 
-%: out/%_asyncify.wasm out/%_wasmfx.wasm out/%_asyncify.cwasm out/%_wasmfx.cwasm
+%: out/%_asyncify.wasm out/%_wasmfx.wasm out/%_asyncify.cwasm out/%_wasmfx.cwasm out/%_asyncify.stripped.wasm out/%_wasmfx.stripped.wasm
 	@echo Made $@ #from $^
 
 $(SWITCH_BENCHMARKS): %: out/%_switch_asyncify.wasm out/%_switch_wasmfx.wasm

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ out/%_switch_wasmfx.wasm: examples/%_switch.c inc/fiber_switch.h src/wasmfx/impo
 	$(WASM_MERGE) $(WASM_MERGE_FLAGS) fiber_switch_wasmfx_imports.wasm "fiber_switch_wasmfx_imports" $(@:.wasm=.pre.wasm) "main" -o $@
 	chmod +x $@
 
+out/%.stripped.wasm: out/%.wasm
+	$(WASM_OPT) $(BINARYEN_FLAGS) --strip $< -o $@
+
 out/%.cwasm: out/%.wasm
 	$(WASMTIME) compile -W=exceptions,function-references,gc,stack-switching -O opt-level=2 $< -o $@
 
@@ -60,6 +63,12 @@ src/wasmfx/imports.wat: src/wasmfx/imports.wat.pp
 
 src/wasmfx/imports_switch.wat: src/wasmfx/imports_switch.wat.pp
 	$(WASICC) -xc $(SHADOW_STACK_FLAG) -DWASMFX_CONT_TABLE_INITIAL_CAPACITY=$(WASMFX_CONT_TABLE_INITIAL_CAPACITY) -E src/wasmfx/imports_switch.wat.pp | sed 's/^#.*//g' > src/wasmfx/imports_switch.wat
+
+%.svg: %.dot
+	dot -Tsvg $< > $@
+
+%.callgraph.dot: %.wasm
+	$(WASM_OPT) --print-call-graph $< -o $@
 
 out:
 	mkdir -p out

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,10 @@ out/%_switch_wasmfx.wasm: examples/%_switch.c inc/fiber_switch.h src/wasmfx/impo
 	$(WASM_MERGE) $(WASM_MERGE_FLAGS) fiber_switch_wasmfx_imports.wasm "fiber_switch_wasmfx_imports" $(@:.wasm=.pre.wasm) "main" -o $@
 	chmod +x $@
 
-out/%.stripped.wasm: out/%.wasm
+out/%_wasmfx.stripped.wasm: out/%_wasmfx.wasm
+	$(WASM_OPT) $(BINARYEN_FLAGS) --strip $< -o $@
+
+out/%_asyncify.stripped.wasm: out/%_asyncify.wasm
 	$(WASM_OPT) $(BINARYEN_FLAGS) --strip $< -o $@
 
 out/%.cwasm: out/%.wasm


### PR DESCRIPTION
For the "binary size" charts, we should compare the "stripped" executables. Add a new make recipe for generating those.

(I noticed that the 6x difference between wasmfx and asyncify was mostly in the data section; this change makes it closer to a +30% difference on the examples I looked at.)

Also I found this useful --print-call-graph option in binaryen which I started plotting, so I figured I'd automate that.