### PR TITLE
Resize itersum to wash out startup costs (process startup and fiber startup).

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Buildscript that generates scripts to run them on the three wasm engines of interest (d8, wasmtime, and wizard). 
+Buildscript that generates scripts to run them on the three wasm engines of interest (d8, wasmtime, and wizard).
 The generated scripts are in /run-scripts and can be executed with `./run-scripts/benchmark_engine_mode.sh`,
 e.g. `./run-scripts/sieve1_d8_wasmfx.sh`.
 Usage:  `./build.py --help`
@@ -65,14 +65,14 @@ def generate_scripts(benchmark: str, engines: list[str]):
                     engine_path=config["D8_PATH"]
                     engine_options=config["D8_OPTIONS"]
                     suffix="wasm"
-            # stick this all into the script template       
+            # stick this all into the script template
             content = SCRIPT_TEMPLATE.format(
                 engine_path=engine_path,
                 engine_options=engine_options,
                 benchmark=benchmark,
                 mode=mode,
                 suffix=suffix,
-                arg=arg, 
+                arg=arg,
             )
             make_script(Path("run-scripts/" + script_name), content)
 

--- a/config.yml
+++ b/config.yml
@@ -30,10 +30,10 @@ BENCHMARKS_FIBER_C : [
 
 # Arguments for benchmarks that require arguments
 BENCHMARK_ARGS : {
-    "itersum": 1000000,
+    "itersum": 100000000,
     "treesum": 25,
     "sieve": 2000,
-    "itersum_switch": 1000000,
+    "itersum_switch": 100000000,
     "treesum_switch": 25,
 }
 


### PR DESCRIPTION
At this size it takes around a second and a half. We could go even bigger, although I think ~ a second is about right.