### PR TITLE
Add switch experiments to benchmarking script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ else
 endif
 
 .PHONY: all
-BENCHMARKS= hello c10m hello itersum pi sieve skynet state treesum treesumlinear
-SWITCH_BENCHMARKS= hello itersum treesum
+BENCHMARKS= hello c10m hello itersum pi sieve skynet state treesum treesumlinear scheduler
+SWITCH_BENCHMARKS= hello itersum treesum pi scheduler
 
 # This strange invocation tells make not to delete "intermediate products".
 .SECONDARY:
@@ -20,7 +20,7 @@ all: $(BENCHMARKS) $(SWITCH_BENCHMARKS)
 %: out/%_asyncify.wasm out/%_wasmfx.wasm out/%_asyncify.cwasm out/%_wasmfx.cwasm out/%_asyncify.stripped.wasm out/%_wasmfx.stripped.wasm
 	@echo Made $@ #from $^
 
-$(SWITCH_BENCHMARKS): %: out/%_switch_asyncify.wasm out/%_switch_wasmfx.wasm
+$(SWITCH_BENCHMARKS): %: out/%_switch_asyncify.wasm out/%_switch_wasmfx.wasm out/%_switch_asyncify.stripped.wasm out/%_switch_wasmfx.stripped.wasm
 
 out/%_asyncify.wasm: examples/%.c inc/fiber.h src/asyncify/asyncify_impl.c | out
 	$(WASICC) -DSTACK_POOL_SIZE=$(STACK_POOL_SIZE) -DASYNCIFY_DEFAULT_STACK_SIZE=$(ASYNCIFY_DEFAULT_STACK_SIZE) src/asyncify/asyncify_impl.c $(WASI_FLAGS) $< -o $(@:.wasm=.pre.wasm)

--- a/bench.py
+++ b/bench.py
@@ -18,16 +18,19 @@ from pathlib import Path
 config = yaml.safe_load(open("config.yml"))
 
 all_benchmarks = config["BENCHMARKS_FIBER_C"]
-all_engines = config["ENGINES"]
+switch_benchmarks = config["BENCHMARKS_FIBER_C_SWITCH"]
 
-def call_buildscript():
+all_engines = config["ENGINES"]
+switch_engines = config["ENGINES_SWITCH"]
+
+def generate_scripts():
     subprocess.check_call(["./build.py"])
 
 def run_benchmarks(benchmarks, engines, filename, path):
     # call hyperfine to run wasmfx benchmarks
-    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_wasmfx.json", "--export-csv", f"bench_results/{path}/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
+    subprocess.check_call(["hyperfine", "--warmup", "1", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_wasmfx.json", "--export-csv", f"bench_results/{path}/{filename}_wasmfx.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_wasmfx.sh"])
     # and now asyncify benchmarks
-    subprocess.check_call(["hyperfine", "--warmup", "3", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_asyncify.json", "--export-csv", f"bench_results/{path}/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
+    subprocess.check_call(["hyperfine", "--warmup", "1", "--runs", "10", "--export-json", f"bench_results/{path}/{filename}_asyncify.json", "--export-csv", f"bench_results/{path}/{filename}_asyncify.csv", "-L", "benchmark", ",".join(benchmarks), "-L", "engine", ",".join(engines), "run-scripts/./{benchmark}_{engine}_asyncify.sh"])
 
 def get_binary_sizes(benchmarks,filename, path):
     data=[]
@@ -53,34 +56,56 @@ def main():
         "--engines", nargs="*", help="List of engines to run (d8, wasmtime, wizard)",
         default=all_engines
     )
+    parser.add_argument(
+        "--switch", help="Run switch experiments as well (benchmarks must have a switch counterpart, e.g. itersum and itersum_switch)",
+        default=False, action="store_true"
+    )
     parser.add_argument("--output", "-o", help="Subdirectory to save results to. Default is `results`, e.g. bench_results/results",
         default="results"
     )
     args = parser.parse_args()
 
-    if not set(args.benchmarks).issubset(set(all_benchmarks)):
-        raise ValueError(f"Error: invalid benchmark name(s). Valid options are: {', '.join(all_benchmarks)}")
-
-    if not set(args.engines).issubset(set(all_engines)):
-        raise ValueError(f"Error: invalid engine name(s). Valid options are: {', '.join(all_engines)}")
+    # Some input validation
+    if args.switch:
+        if not set(args.benchmarks).issubset(set(switch_benchmarks)):
+            raise ValueError(f"Error: invalid switch benchmark name(s). Valid options are: {', '.join(switch_benchmarks)}")
+        if not set(args.engines).issubset(set(switch_engines)):
+            raise ValueError(f"Error: invalid switch engine name(s). Valid options are: {', '.join(switch_engines)}")
+    else:
+        if not set(args.benchmarks).issubset(set(all_benchmarks)):
+            raise ValueError(f"Error: invalid benchmark name(s). Valid options are: {', '.join(all_benchmarks)}")
+        if not set(args.engines).issubset(set(all_engines)):
+            raise ValueError(f"Error: invalid engine name(s). Valid options are: {', '.join(all_engines)}")
 
     path = args.output
 
-    # build and run everything
-    call_buildscript()
     # make nice output directories
     os.makedirs(f"bench_results/{path}", exist_ok=True)
     os.makedirs(f"bench_results/{path}/charts/absolute_benchmarks", exist_ok=True)
     os.makedirs(f"bench_results/{path}/charts/absolute_engines", exist_ok=True)
     os.makedirs(f"bench_results/{path}/charts/relative", exist_ok=True)
+    # generate the benchmarking scripts
+    generate_scripts()
+    # compile the wasm binaries for each benchmark (the buildscript does this for both switch and non-switch benchmarks in the same call)
+    for benchmark in args.benchmarks:
+        subprocess.check_call(["make", benchmark])
+    # now update benchmarks to include switch versions of the selected benchmarks, e.g. if user selects "itersum", also add "itersum_switch"
+    args.benchmarks = list(zip([b + "_switch" for b in args.benchmarks], args.benchmarks))
+    args.benchmarks = list(sum(args.benchmarks, ())) # flatten list of tuples
     # get binary size data
     get_binary_sizes(args.benchmarks,"binary_sizes", path)
     # make binary size chart
     os.system(f"python3 plot_binary_sizes.py bench_results/{path}/binary_sizes.json --benchmarks {' '.join(args.benchmarks)} -o bench_results/{path}/charts")
     # run benchmarks to obtain runtime data
     run_benchmarks(args.benchmarks, args.engines, "results", path)
-    # make runtime chart
+    # make runtime charts
     os.system(f"python3 plot_benchmarks.py bench_results/{path}/results_wasmfx.json bench_results/{path}/results_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts")
+    # Make extra charts for switch benchmarks
+    if args.switch:
+        # Put the extra charts in this directory
+        os.makedirs(f"bench_results/{path}/charts/switch", exist_ok=True)
+        # Run the switch-specific chart script on the wasmfx result file only
+        os.system(f"python3 plot_benchmarks_switch.py bench_results/{path}/results_wasmfx.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts/switch")
 
 if __name__ == "__main__":
     main()

--- a/bench.py
+++ b/bench.py
@@ -89,9 +89,11 @@ def main():
     # compile the wasm binaries for each benchmark (the buildscript does this for both switch and non-switch benchmarks in the same call)
     for benchmark in args.benchmarks:
         subprocess.check_call(["make", benchmark])
-    # now update benchmarks to include switch versions of the selected benchmarks, e.g. if user selects "itersum", also add "itersum_switch"
-    args.benchmarks = list(zip([b + "_switch" for b in args.benchmarks], args.benchmarks))
-    args.benchmarks = list(sum(args.benchmarks, ())) # flatten list of tuples
+    # if running switch experiments, update benchmarks to include switch versions of the selected benchmarks
+    #    e.g. if user selects "itersum", also add "itersum_switch"
+    if args.switch:
+        args.benchmarks = list(zip([b + "_switch" for b in args.benchmarks], args.benchmarks))
+        args.benchmarks = list(sum(args.benchmarks, ())) # flatten list of tuples
     # get binary size data
     get_binary_sizes(args.benchmarks,"binary_sizes", path)
     # make binary size chart

--- a/bench.py
+++ b/bench.py
@@ -21,7 +21,11 @@ all_benchmarks = config["BENCHMARKS_FIBER_C"]
 switch_benchmarks = config["BENCHMARKS_FIBER_C_SWITCH"]
 
 all_engines = config["ENGINES"]
-switch_engines = config["ENGINES_SWITCH"]
+
+def disabled(engine, benchmark, style):
+    if engine == "wasmtime" and style == "switch":
+        return True
+    return False
 
 def generate_scripts():
     subprocess.check_call(["./build.py"])
@@ -69,15 +73,17 @@ def main():
     if args.switch:
         if not set(args.benchmarks).issubset(set(switch_benchmarks)):
             raise ValueError(f"Error: invalid switch benchmark name(s). Valid options are: {', '.join(switch_benchmarks)}")
-        if not set(args.engines).issubset(set(switch_engines)):
-            raise ValueError(f"Error: invalid switch engine name(s). Valid options are: {', '.join(switch_engines)}")
+        # Can't run switch experiments on wasmtime right now so we are banning that option
+        if not set(args.engines).issubset(set(["d8", "wizard"])):
+            raise ValueError(f"Error: invalid engine name(s). Valid options are: d8, wizard (switch experiments are currently broken on wasmtime)")
     else:
         if not set(args.benchmarks).issubset(set(all_benchmarks)):
             raise ValueError(f"Error: invalid benchmark name(s). Valid options are: {', '.join(all_benchmarks)}")
-        if not set(args.engines).issubset(set(all_engines)):
-            raise ValueError(f"Error: invalid engine name(s). Valid options are: {', '.join(all_engines)}")
+    if not set(args.engines).issubset(set(all_engines)):
+        raise ValueError(f"Error: invalid engine name(s). Valid options are: {', '.join(all_engines)}")
 
     path = args.output
+    benchmarks_to_run = args.benchmarks
 
     # make nice output directories
     os.makedirs(f"bench_results/{path}", exist_ok=True)
@@ -87,27 +93,27 @@ def main():
     # generate the benchmarking scripts
     generate_scripts()
     # compile the wasm binaries for each benchmark (the buildscript does this for both switch and non-switch benchmarks in the same call)
-    for benchmark in args.benchmarks:
+    for benchmark in benchmarks_to_run:
         subprocess.check_call(["make", benchmark])
     # if running switch experiments, update benchmarks to include switch versions of the selected benchmarks
     #    e.g. if user selects "itersum", also add "itersum_switch"
     if args.switch:
-        args.benchmarks = list(zip([b + "_switch" for b in args.benchmarks], args.benchmarks))
-        args.benchmarks = list(sum(args.benchmarks, ())) # flatten list of tuples
+        benchmarks_to_run = list(zip([b + "_switch" for b in benchmarks_to_run], benchmarks_to_run))
+        benchmarks_to_run = list(sum(benchmarks_to_run, ())) # flatten list of tuples
     # get binary size data
-    get_binary_sizes(args.benchmarks,"binary_sizes", path)
+    get_binary_sizes(benchmarks_to_run,"binary_sizes", path)
     # make binary size chart
-    os.system(f"python3 plot_binary_sizes.py bench_results/{path}/binary_sizes.json --benchmarks {' '.join(args.benchmarks)} -o bench_results/{path}/charts")
+    os.system(f"python3 plot_binary_sizes.py bench_results/{path}/binary_sizes.json --benchmarks {' '.join(benchmarks_to_run)} -o bench_results/{path}/charts")
     # run benchmarks to obtain runtime data
-    run_benchmarks(args.benchmarks, args.engines, "results", path)
+    run_benchmarks(benchmarks_to_run, args.engines, "results", path)
     # make runtime charts
-    os.system(f"python3 plot_benchmarks.py bench_results/{path}/results_wasmfx.json bench_results/{path}/results_asyncify.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts")
+    os.system(f"python3 plot_benchmarks.py bench_results/{path}/results_wasmfx.json bench_results/{path}/results_asyncify.json --benchmarks {' '.join(benchmarks_to_run)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts")
     # Make extra charts for switch benchmarks
     if args.switch:
         # Put the extra charts in this directory
         os.makedirs(f"bench_results/{path}/charts/switch", exist_ok=True)
         # Run the switch-specific chart script on the wasmfx result file only
-        os.system(f"python3 plot_benchmarks_switch.py bench_results/{path}/results_wasmfx.json --benchmarks {' '.join(args.benchmarks)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts/switch")
+        os.system(f"python3 plot_benchmarks_switch.py bench_results/{path}/results_wasmfx.json --benchmarks {' '.join(benchmarks_to_run)} --engines {' '.join(args.engines)} -o bench_results/{path}/charts/switch")
 
 if __name__ == "__main__":
     main()

--- a/build.py
+++ b/build.py
@@ -2,9 +2,9 @@
 """
 Buildscript that generates scripts to run them on the three wasm engines of interest (d8, wasmtime, and wizard). 
 The generated scripts are in /run-scripts and can be executed with `./run-scripts/benchmark_engine_mode.sh`,
-e.g. `./run-scripts/sieve1_d8_wasmfx.sh`.
-Usage:  `./build.py --help`
-        `./build.py --engines d8 wasmtime` to only generate scripts for d8 and wasmtime.
+e.g. `./run-scripts/sieve1_d8_wasmfx.sh`. Configurations are in config.yml.
+
+Usage:  `./build.py`
 """
 
 import argparse
@@ -15,10 +15,6 @@ from pathlib import Path
 
 # Import config
 config = yaml.safe_load(open("config.yml"))
-
-# Given a benchmark name, build .wasm files for both asyncify and wasmfx modes.
-def build_benchmarks():
-    subprocess.run(["make", "all"])
 
 # ---- Script generation ----
 
@@ -77,16 +73,13 @@ def generate_scripts(benchmark: str, engines: list[str]):
             make_script(Path("run-scripts/" + script_name), content)
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--engines", nargs="*", choices=list(config["ENGINES"]), help="Build and generate scripts for specified engine(s)",
-        default=config["ENGINES"]
-    )
-    args = parser.parse_args()
-    build_benchmarks()
     for benchmark in config["BENCHMARKS_FIBER_C"]:
-        generate_scripts(benchmark,args.engines)
+        generate_scripts(benchmark, config["ENGINES"])
         print("Generated scripts for benchmark:", benchmark)
+    for benchmark in config["BENCHMARKS_FIBER_C_SWITCH"]:
+        benchmark_name = benchmark + "_switch"
+        generate_scripts(benchmark_name, config["ENGINES_SWITCH"])
+        print("Generated scripts for benchmark:", benchmark_name)
 
 if __name__ == "__main__":
     main()

--- a/build.py
+++ b/build.py
@@ -78,7 +78,7 @@ def main():
         print("Generated scripts for benchmark:", benchmark)
     for benchmark in config["BENCHMARKS_FIBER_C_SWITCH"]:
         benchmark_name = benchmark + "_switch"
-        generate_scripts(benchmark_name, config["ENGINES_SWITCH"])
+        generate_scripts(benchmark_name, config["ENGINES"])
         print("Generated scripts for benchmark:", benchmark_name)
 
 if __name__ == "__main__":

--- a/config.yml
+++ b/config.yml
@@ -1,9 +1,6 @@
 # List of valid engines
 ENGINES : [ "d8", "wasmtime", "wizard" ]
 
-# List of valid engines for switch experiments
-ENGINES_SWITCH : [ "d8", "wizard" ] # switch is still broken on wasmtime
-
 # Paths to engines and engine-specific options
 # Wasmtime
 WASMTIME_PATH : "/opt/wasmfx/wasmfxtime/target/release/wasmtime"

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,9 @@
 # List of valid engines
 ENGINES : [ "d8", "wasmtime", "wizard" ]
 
+# List of valid engines for switch experiments
+ENGINES_SWITCH : [ "d8", "wizard" ] # switch is still broken on wasmtime
+
 # Paths to engines and engine-specific options
 # Wasmtime
 WASMTIME_PATH : "/opt/wasmfx/wasmfxtime/target/release/wasmtime"
@@ -20,20 +23,26 @@ BENCHMARKS_FIBER_C : [
     "sieve",
     "state",
     "treesum",
-    #"treesumlinear",
     "c10m",
     "pi",
     "skynet",
-    "itersum_switch",
-    "treesum_switch",
+    "scheduler",
   ]
+
+# List of switch benchmarks
+BENCHMARKS_FIBER_C_SWITCH : [
+    "itersum",
+    "treesum",
+    "pi",
+    "scheduler",
+]
 
 # Arguments for benchmarks that require arguments
 BENCHMARK_ARGS : {
-    "itersum": 1000000,
+    "itersum": 100000000,
     "treesum": 25,
     "sieve": 2000,
-    "itersum_switch": 1000000,
+    "itersum_switch": 100000000,
     "treesum_switch": 25,
 }
 

--- a/plot_benchmarks_switch.py
+++ b/plot_benchmarks_switch.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "matplotlib",
+#     "pyqt6",
+#     "numpy",
+# ]
+# ///
+"""
+Script that generates a bar chart displaying the relative performance of switch/non-switch benchmarks for each engine
+
+Usage: 
+    `python3 plot_benchmarks.py results_wasmfx.json --benchmarks itersum --engines wasmtime d8 -o results_dir`
+"""
+
+import argparse
+import json
+import pathlib
+import matplotlib.pyplot as plt
+import numpy as np
+import math
+
+# deal with inputs
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("files", type=pathlib.Path, help="JSON file with benchmark results")
+parser.add_argument("--benchmarks", nargs="*", help="List of benchmarks to run (sieve, itersum, treesum)")
+parser.add_argument("--engines", nargs="*", help="List of engines to run (d8, wasmtime, wizard)")
+parser.add_argument("-o", "--output", help="Save image to the given filename")
+
+args = parser.parse_args()
+benches = args.benchmarks
+engines = args.engines
+
+# Parse JSON files to extract benchmark results, we are only interested in the mean times
+data = []
+
+# Make an array where each row corresponds to a benchmark/engine pair, each column corresponds to a backend (switch vs non-switch), 
+# and the values are the mean runtimes from the hyperfine output json file
+with open(args.files) as f:
+    results = json.load(f)["results"]
+data.append([round(b["mean"], 6) for b in results])
+
+# Unpack data from list of lists
+data = data[0]
+# The width of the bars in the chart
+width = 1
+# Hope this is colourblind-friendly enough for sam
+bar_colors = ['tab:blue', 'tab:orange', 'tab:cyan', 'tab:red', 'tab:purple', 'tab:brown', 'tab:pink', 'tab:gray']
+
+# --------------
+# ----- Absolute times for switch and non-switch for each benchmark, one chart per engine -----
+# --------------
+
+for i, engine in enumerate(engines):
+    # The data varies parameters in the order: benchmark -> switch -> engine
+    # Therefore, data for each engine is obtained by:
+    engine_data = [data[j] for j in range(i * len(benches), (i+1) * len(benches))]
+
+    # Set x values for bar locations, with one group of (two) bars for each switch/non-switch pair
+    # Logic: for each benchmark we allocate three bars, where the third one is a gap, so we don't 
+    # have multiples of 3 in our list of x-values. 
+    bar_loc = [x for x in np.arange((len(benches) / 2) * 3) if ((x+1) % 3) != 0]
+
+    # Plot data
+    fig, ax = plt.subplots()
+    for i in range(len(engine_data)):
+        ax.bar(bar_loc[i], engine_data[i], width, label=benches[i % len(benches)], color=bar_colors[i % 2])
+
+    # Set x-axis labels to be benchmark names, with one label per switch/non-switch pair
+    axis_labels = np.repeat([benches[i] for i in range(len(benches)) if i % 2 == 1] , 2)
+    ax.set_xticks([x + 0.5 for x in bar_loc], axis_labels)
+
+    # Keeps every other label, make the rest invisible
+    [l.set_visible(False) for (i,l) in enumerate(ax.xaxis.get_ticklabels()) if (i+1) % 2 == 0]
+
+    # Readability features
+    ax.grid(visible=True, axis="y")
+    plt.title(f"Switch benchmark results (absolute times) for {engine}")
+    plt.xlabel("Benchmark")
+    plt.ylabel("Time (seconds)")
+    plt.legend(['Switch', 'Non-switch'], bbox_to_anchor=(1.3, 1), loc="upper right")
+
+    # Export figure
+    if args.output:
+        plt.savefig(f"{args.output}/switch_{engine}", bbox_inches="tight")
+    else:
+        plt.show()


### PR DESCRIPTION
Now you can run the switch experiment alongside the normal wasmfx/asyncify one by running:

`./bench.py --benchmarks itersum treesum scheduler pi --engines d8 --switch`

This tells bench.py to generate a separate chart that compares the performance of the switch versions of these benchmarks with the non-switch versions.

This is a duplicate of https://github.com/wasmfx/fiber-c/pull/68 which I closed because I accidentally requested a review from copilot in that one. Sorry!