### PR TITLE
Add scheduler benchmarks

### DIFF
--- a/examples/scheduler.c
+++ b/examples/scheduler.c
@@ -1,7 +1,13 @@
+// Benchmark that runs 10 fibers at the same time, each fiber increments 
+// a number. Intended as an itersum-analogue that exhibits what we get 
+// from using the switch instruction over resume/suspend in a green 
+// threads-like setting.
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include <fiber.h>
 
@@ -9,6 +15,10 @@
 #define PRINT_RESULTS 0
 #define NUM_WORKERS 10
 #define SWITCHES 10000000
+
+// Global state for scheduler
+bool keep_going = true;
+uint32_t next = 0;
 
 // Array of workers
 static fiber_t workers[NUM_WORKERS];
@@ -18,6 +28,38 @@ static bool worker_status[NUM_WORKERS];
 
 // Array of results
 static int32_t results[NUM_WORKERS];
+
+void update_state() {
+  // Update global variable `next` to point to the next available worker (if any).
+  uint32_t i = 0;
+  for (next = (next + 1) % NUM_WORKERS; i < NUM_WORKERS; ++i, next = (next+1) % NUM_WORKERS) {
+    if (!worker_status[next]) {
+      break;
+    }
+  }
+  // Update keep_going variable too
+  keep_going = i < NUM_WORKERS;
+}
+
+void scheduler() {
+  fiber_result_t status;
+  // Run next worker for one step.
+  do {
+    (void)fiber_resume(workers[next], &results[next], &status);
+    switch (status) {
+    case FIBER_OK:
+      worker_status[next] = true;
+      break;
+    case FIBER_YIELD:
+      break;
+    case FIBER_ERROR:
+      abort(); // A fiber should never enter the error state.
+      break;
+    }
+  // Find the next available worker and determine if we should keep going.
+  update_state();
+  } while (keep_going);
+}
 
 void* increment(void *arg) {
   int32_t *result = (int32_t*)(intptr_t)arg;
@@ -41,41 +83,18 @@ int main(void) {
     worker_status[i] = false;
   }
 
-  // Scheduler
-  bool keep_going = true;
-  uint32_t next = 0;
-  fiber_result_t status;
-  do {
-    (void)fiber_resume(workers[next], &results[next], &status);
-    switch (status) {
-    case FIBER_OK:
-      worker_status[next] = true;
-      break;
-    case FIBER_YIELD:
-      break;
-    case FIBER_ERROR:
-      abort(); // A fiber should never enter the error state.
-      break;
-    }
-
-    // Find the next available worker.
-    uint32_t i = 0;
-    for (next = (next + 1) % NUM_WORKERS; i < NUM_WORKERS; ++i, next = (next+1) % NUM_WORKERS) {
-      if (!worker_status[next]) {
-        break;
-      }
-    }
-    keep_going = i < NUM_WORKERS;
-  } while (keep_going);
+  // Call scheduler to start running workers.
+  scheduler();
 
   #if PRINT_RESULTS
   for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
     printf("%d\n", results[i]);
   }
   #endif
-
-  // Clean up
+  
+  // Validate results and clean up
   for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    assert(results[i] == SWITCHES);
     fiber_free(workers[i]);
   }
 
@@ -84,3 +103,4 @@ int main(void) {
 
 #undef PRINT_RESULTS
 #undef NUM_WORKERS
+#undef SWITCHES

--- a/examples/scheduler.c
+++ b/examples/scheduler.c
@@ -1,0 +1,86 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <fiber.h>
+
+// Parameters
+#define PRINT_RESULTS 0
+#define NUM_WORKERS 10
+#define SWITCHES 10000000
+
+// Array of workers
+static fiber_t workers[NUM_WORKERS];
+
+// Array of statuses
+static bool worker_status[NUM_WORKERS];
+
+// Array of results
+static int32_t results[NUM_WORKERS];
+
+void* increment(void *arg) {
+  int32_t *result = (int32_t*)(intptr_t)arg;
+  for (uint32_t i = 0; i < SWITCHES; ++i) {
+    // Increment result
+    (*result)++;
+    (void)fiber_yield(NULL);
+  }
+  return NULL;
+}
+
+int main(void) {
+  fiber_init();
+
+  // Spawn workers.
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    workers[i] = fiber_alloc(increment);
+  }
+  // Initialize statuses
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    worker_status[i] = false;
+  }
+
+  // Scheduler
+  bool keep_going = true;
+  uint32_t next = 0;
+  fiber_result_t status;
+  do {
+    (void)fiber_resume(workers[next], &results[next], &status);
+    switch (status) {
+    case FIBER_OK:
+      worker_status[next] = true;
+      break;
+    case FIBER_YIELD:
+      break;
+    case FIBER_ERROR:
+      abort(); // A fiber should never enter the error state.
+      break;
+    }
+
+    // Find the next available worker.
+    uint32_t i = 0;
+    for (next = (next + 1) % NUM_WORKERS; i < NUM_WORKERS; ++i, next = (next+1) % NUM_WORKERS) {
+      if (!worker_status[next]) {
+        break;
+      }
+    }
+    keep_going = i < NUM_WORKERS;
+  } while (keep_going);
+
+  #if PRINT_RESULTS
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    printf("%d\n", results[i]);
+  }
+  #endif
+
+  // Clean up
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    fiber_free(workers[i]);
+  }
+
+  fiber_finalize();
+}
+
+#undef PRINT_RESULTS
+#undef NUM_WORKERS

--- a/examples/scheduler_switch.c
+++ b/examples/scheduler_switch.c
@@ -1,3 +1,8 @@
+// Benchmark that runs 10 fibers at the same time, each fiber increments 
+// a number. Intended as an itersum-analogue that exhibits what we get 
+// from using the switch instruction over resume/suspend in a green 
+// threads-like setting.
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -42,7 +47,7 @@ void scheduler(bool worker_done, fiber_t caller) {
   if (worker_done) {
     // Mark the current worker as done.
     worker_status[next] = true;
-    // Determine whether we should keep going.
+    // Find the next available worker and determine if we should keep going.
     update_state();
     if (!keep_going) {
       // If no more available workers, switch-return to the outer loop.     
@@ -98,13 +103,15 @@ int main(int argc, char **argv) {
   }
   #endif
 
-  // Clean up
+  // Validate results and clean up
   for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    assert(results[i] == SWITCHES);
     fiber_free(workers[i]);
   }
-
+  
   return 0;
 }
 
 #undef PRINT_RESULTS
 #undef NUM_WORKERS
+#undef SWITCHES

--- a/examples/scheduler_switch.c
+++ b/examples/scheduler_switch.c
@@ -15,10 +15,6 @@
 #define NUM_WORKERS 10
 #define SWITCHES 10000000
 
-// Global state for scheduler
-bool keep_going = true;
-uint32_t next = 0;
-
 // Array of workers
 static fiber_t workers[NUM_WORKERS];
 
@@ -28,43 +24,41 @@ static bool worker_status[NUM_WORKERS];
 // Array of results
 static int32_t results[NUM_WORKERS];
 
-// Reference to main loop
-fiber_t main_fiber;
-
-void update_state() { 
+void find_worker(bool* keep_going, uint32_t* next) { 
   // Update global variable `next` to point to the next available worker (if any).
   uint32_t i = 0;
-  for (next = (next + 1) % NUM_WORKERS; i < NUM_WORKERS; ++i, next = (next+1) % NUM_WORKERS) {
-    if (!worker_status[next]) {
+  for (*next = (*next + 1) % NUM_WORKERS; i < NUM_WORKERS; ++i, *next = (*next+1) % NUM_WORKERS) {
+    if (!worker_status[*next]) {
       break;
     }
   }
   // Update keep_going variable too
-  keep_going = i < NUM_WORKERS - 1;
+  *keep_going = i < NUM_WORKERS - 1;
 }
 
 void scheduler(bool worker_done, fiber_t caller) { 
+  static bool keep_going = true;
+  static uint32_t next = 0;
+
   if (worker_done) {
     // Mark the current worker as done.
     worker_status[next] = true;
     // Find the next available worker and determine if we should keep going.
-    update_state();
+    find_worker(&keep_going, &next);
     if (!keep_going) {
-      // If no more available workers, switch-return to the outer loop.     
-      fiber_switch_return(main_fiber, NULL);
+      // If no more available workers, return to the outer loop.     
+      return;
     } else {
       // If the current worker is done, switch-return to the next available worker.
       fiber_switch_return(workers[next], &results[next]);
     }    
   }
   // Otherwise, simply determine and switch onto the next available worker.
-  update_state();
+  find_worker(&keep_going, &next);
   fiber_switch(workers[next],&results[next],&caller); 
 }
 
 void* increment(void *arg, fiber_t caller) {
-  // Save reference to main loop if this is the first entry to the first worker
-  if (next == 0) { main_fiber = caller; }
   // Pointer to final result
   assert(arg && "null argument");
   int32_t result = *((int32_t*)(intptr_t)arg);
@@ -75,6 +69,9 @@ void* increment(void *arg, fiber_t caller) {
     // Scheduler will call switch
     scheduler(false, caller);
   }
+
+  // Save result
+  *(int32_t *)arg = result;
   // Scheduler will call switch-return
   scheduler(true, caller);
   // unreachable

--- a/examples/scheduler_switch.c
+++ b/examples/scheduler_switch.c
@@ -1,0 +1,110 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <fiber_switch.h>
+
+// Parameters
+#define PRINT_RESULTS 0
+#define NUM_WORKERS 10
+#define SWITCHES 10000000
+
+// Global state for scheduler
+bool keep_going = true;
+uint32_t next = 0;
+
+// Array of workers
+static fiber_t workers[NUM_WORKERS];
+
+// Array of statuses
+static bool worker_status[NUM_WORKERS];
+
+// Array of results
+static int32_t results[NUM_WORKERS];
+
+// Reference to main loop
+fiber_t main_fiber;
+
+void update_state() { 
+  // Update global variable `next` to point to the next available worker (if any).
+  uint32_t i = 0;
+  for (next = (next + 1) % NUM_WORKERS; i < NUM_WORKERS; ++i, next = (next+1) % NUM_WORKERS) {
+    if (!worker_status[next]) {
+      break;
+    }
+  }
+  // Update keep_going variable too
+  keep_going = i < NUM_WORKERS - 1;
+}
+
+void scheduler(bool worker_done, fiber_t caller) { 
+  if (worker_done) {
+    // Mark the current worker as done.
+    worker_status[next] = true;
+    // Determine whether we should keep going.
+    update_state();
+    if (!keep_going) {
+      // If no more available workers, switch-return to the outer loop.     
+      fiber_switch_return(main_fiber, NULL);
+    } else {
+      // If the current worker is done, switch-return to the next available worker.
+      fiber_switch_return(workers[next], &results[next]);
+    }    
+  }
+  // Otherwise, simply determine and switch onto the next available worker.
+  update_state();
+  fiber_switch(workers[next],&results[next],&caller); 
+}
+
+void* increment(void *arg, fiber_t caller) {
+  // Save reference to main loop if this is the first entry to the first worker
+  if (next == 0) { main_fiber = caller; }
+  // Pointer to final result
+  int32_t *result = (int32_t*)(intptr_t)arg;
+
+  for (uint32_t i = 0; i < SWITCHES; ++i) {
+    // Increment result
+    (*result)++;
+    // Scheduler will call switch
+    scheduler(false, caller);
+  }
+  // Scheduler will call switch-return
+  scheduler(true, caller);
+  // unreachable
+  return NULL;
+}
+
+void *prog(int __attribute__((unused)) argc, char __attribute__((unused)) **argv) {
+  // Spawn workers.
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    workers[i] = fiber_alloc(increment);
+  }
+  // Initialize statuses
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    worker_status[i] = false;
+  }
+  // Switch onto the initial worker
+  fiber_switch(workers[0], &results[0], &workers[0]);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  fiber_main(prog, argc, argv);
+
+  #if PRINT_RESULTS
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    printf("%d\n", results[i]);
+  }
+  #endif
+
+  // Clean up
+  for (uint32_t i = 0; i < NUM_WORKERS; ++i) {
+    fiber_free(workers[i]);
+  }
+
+  return 0;
+}
+
+#undef PRINT_RESULTS
+#undef NUM_WORKERS

--- a/examples/scheduler_switch.c
+++ b/examples/scheduler_switch.c
@@ -66,11 +66,12 @@ void* increment(void *arg, fiber_t caller) {
   // Save reference to main loop if this is the first entry to the first worker
   if (next == 0) { main_fiber = caller; }
   // Pointer to final result
-  int32_t *result = (int32_t*)(intptr_t)arg;
+  assert(arg && "null argument");
+  int32_t result = *((int32_t*)(intptr_t)arg);
 
   for (uint32_t i = 0; i < SWITCHES; ++i) {
     // Increment result
-    (*result)++;
+    ++result;
     // Scheduler will call switch
     scheduler(false, caller);
   }


### PR DESCRIPTION
New benchmark that runs 10 fibers at the same time, each fiber increments a number from 0 to 10000000.

I stole the scheduling logic for `scheduler.c` from the existing pi benchmark.