### PR TITLE
Shift inhabited continuation table indices by 1

### DIFF
--- a/src/wasmfx/imports_switch.wat.pp
+++ b/src/wasmfx/imports_switch.wat.pp
@@ -31,12 +31,13 @@
   ;; is in $switch_from_fiber_index and the new one is in $active_fiber_index.
   ;; Also after any switch the target fiber needs to start by storing the
   ;; generated continuation reference at the index specified by
-  ;; $switched_from_fiber_index in the $conts table.
+  ;; $switched_from_fiber_index in the $conts table. Both are initialized
+  ;; to 1 since we reserve index 0 in the continuation table as a null value.
   ;;
   ;; Keeps track of the index, into the continuation table, of the "switched from" continuation
-  (global $switched_from_fiber_index (mut i32) (i32.const 0))
+  (global $switched_from_fiber_index (mut i32) (i32.const 1))
   ;; Keeps track of the currently active continuation
-  (global $active_fiber_index (mut i32) (i32.const 0))
+  (global $active_fiber_index (mut i32) (i32.const 1))
 
   ;; Keep the initial size of this table in sync with INITIAL_TABLE_CAPACITY in
   ;; .c file.
@@ -116,6 +117,9 @@
 
     ;; Save shadow stack prior to invoking the initial trampoline
     (local.set $old_shadow_sp (global.get $sstack_ptr))
+
+    ;; Set both the switched-from and active fiber indices to 1 since
+    ;; we are
 
     ;; The initial continuation invocation is special as we pass argc
     ;; and argv to it.

--- a/src/wasmfx/imports_switch.wat.pp
+++ b/src/wasmfx/imports_switch.wat.pp
@@ -118,9 +118,6 @@
     ;; Save shadow stack prior to invoking the initial trampoline
     (local.set $old_shadow_sp (global.get $sstack_ptr))
 
-    ;; Set both the switched-from and active fiber indices to 1 since
-    ;; we are
-
     ;; The initial continuation invocation is special as we pass argc
     ;; and argv to it.
     (block $done (result i32)

--- a/src/wasmfx/wasmfx_impl.c
+++ b/src/wasmfx/wasmfx_impl.c
@@ -19,10 +19,13 @@ static const uint32_t initial_table_capacity = WASMFX_CONT_TABLE_INITIAL_CAPACIT
 // The current capacity of the `$conts` table.
 static uint32_t cont_table_capacity = initial_table_capacity;
 // Number of entries at the end of `$conts` table that we haven't used so
-// far.
-// Invariant:
+// far. Initialised to initial_table_capacity - 1 because we reserve index 0 
+// of the table for null checks.
+// Invariant before first call to wasmfx_grow_cont_table:
+// `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity - 1`
+// Invariant after wasmfx_grow_cont_table is called:
 // `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity`
-static uint32_t cont_table_unused_size = initial_table_capacity;
+static uint32_t cont_table_unused_size = initial_table_capacity - 1;
 
 // This is a stack of indices into `$conts` that we have previously used, but
 // subsequently freed. Allocated as part of `fiber_init`. Invariant: Once

--- a/src/wasmfx/wasmfx_impl.c
+++ b/src/wasmfx/wasmfx_impl.c
@@ -21,10 +21,8 @@ static uint32_t cont_table_capacity = initial_table_capacity;
 // Number of entries at the end of `$conts` table that we haven't used so
 // far. Initialised to initial_table_capacity - 1 because we reserve index 0 
 // of the table for null checks.
-// Invariant before first call to wasmfx_grow_cont_table:
+// Invariant:
 // `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity - 1`
-// Invariant after wasmfx_grow_cont_table is called:
-// `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity`
 static uint32_t cont_table_unused_size = initial_table_capacity - 1;
 
 // This is a stack of indices into `$conts` that we have previously used, but

--- a/src/wasmfx/wasmfx_switch_impl.c
+++ b/src/wasmfx/wasmfx_switch_impl.c
@@ -21,10 +21,8 @@ static uint32_t cont_table_capacity = initial_table_capacity;
 // Number of entries at the end of `$conts` table that we haven't used so
 // far. Initialised to initial_table_capacity - 1 because we reserve index 0 
 // of the table for null checks.
-// Invariant before first call to wasmfx_grow_cont_table:
+// Invariant:
 // `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity - 1`
-// Invariant after wasmfx_grow_cont_table is called:
-// `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity`
 static_assert(WASMFX_CONT_TABLE_INITIAL_CAPACITY > 0);
 static uint32_t cont_table_unused_size = initial_table_capacity - 1;
 

--- a/src/wasmfx/wasmfx_switch_impl.c
+++ b/src/wasmfx/wasmfx_switch_impl.c
@@ -19,10 +19,13 @@ static const uint32_t initial_table_capacity = WASMFX_CONT_TABLE_INITIAL_CAPACIT
 // The current capacity of the `$conts` table.
 static uint32_t cont_table_capacity = initial_table_capacity;
 // Number of entries at the end of `$conts` table that we haven't used so
-// far.
-// Invariant:
+// far. Initialised to initial_table_capacity - 1 because we reserve index 0 
+// of the table for null checks.
+// Invariant before first call to wasmfx_grow_cont_table:
+// `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity - 1`
+// Invariant after wasmfx_grow_cont_table is called:
 // `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity`
-static uint32_t cont_table_unused_size = initial_table_capacity;
+static uint32_t cont_table_unused_size = initial_table_capacity - 1;
 
 // This is a stack of indices into `$conts` that we have previously used, but
 // subsequently freed. Allocated as part of `fiber_init`. Invariant: Once
@@ -103,7 +106,7 @@ static cont_table_index_t wasmfx_acquire_table_index(void) {
 
     // We added `cont_table_capacity` new entries to the table, and then
     // immediately consume one for the new continuation.
-    cont_table_unused_size = cont_table_capacity - 1;
+    cont_table_unused_size = cont_table_capacity;
     table_index = cont_table_capacity;
     cont_table_capacity = new_cont_table_capacity;
 

--- a/src/wasmfx/wasmfx_switch_impl.c
+++ b/src/wasmfx/wasmfx_switch_impl.c
@@ -25,6 +25,7 @@ static uint32_t cont_table_capacity = initial_table_capacity;
 // `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity - 1`
 // Invariant after wasmfx_grow_cont_table is called:
 // `cont_table_unused_size` + `free_list_size` <= `cont_table_capacity`
+static_assert(WASMFX_CONT_TABLE_INITIAL_CAPACITY > 0);
 static uint32_t cont_table_unused_size = initial_table_capacity - 1;
 
 // This is a stack of indices into `$conts` that we have previously used, but


### PR DESCRIPTION
The easiest way to do this I could think of was to reduce the initial capacity of the continuation table by 1, because table indices are calculated using it. 