### PR TITLE
Resize the pi benchmark.

### DIFF
--- a/examples/pi.c
+++ b/examples/pi.c
@@ -13,7 +13,7 @@
 #define PRINT_RESULTS 0
 #define NUM_TASKS 1000
 // Number of samples taken between yields.
-static uint32_t const BATCH_SIZE = 100000;
+static uint32_t const BATCH_SIZE = 20000;
 // Number of batches to run in total. Each fiber will take YIELDS * BATCH_SIZE samples
 static uint32_t const YIELDS = 50;
 


### PR DESCRIPTION
30sec was way longer than our other benchmarks. The new size runs in around 6s, which I think is adequate for speed-testing and comfortable for running 10 times as part of our usual suite :D