### PR TITLE
Add subplot under all charts with useful information about the benchmarking run

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -39,7 +39,7 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
             "--warmup",
             "1",
             "--runs",
-            "10",
+            "3",
             "--export-json",
             f"bench_results/{path}/{filename}_wasmfx.json",
             "--export-csv",
@@ -54,7 +54,7 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
             "style",
             "wasmfx",
             "run-scripts/{benchmark}_{engine}_wasmfx.sh",
-        ] + ["--show-output"] if show_output else []
+        ] + (["--show-output"] if show_output else [])
     )
     # and now asyncify benchmarks
     subprocess.check_call(
@@ -63,7 +63,7 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
             "--warmup",
             "1",
             "--runs",
-            "10",
+            "3",
             "--export-json",
             f"bench_results/{path}/{filename}_asyncify.json",
             "--export-csv",
@@ -78,7 +78,7 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
             "style",
             "asyncify",
             "run-scripts/{benchmark}_{engine}_asyncify.sh",
-        ] + ["--show-output"] if show_output else []
+        ] + (["--show-output"] if show_output else [])
     )
 
 
@@ -96,6 +96,11 @@ def get_binary_sizes(benchmarks, filename, path):
     with open(f"bench_results/{path}/{filename}.json", "w") as f:
         json.dump(data, f)
 
+def get_run_info():
+    # Run the three scripts in ../run_info
+    subprocess.check_call(["python3", "run_info/compiler_info.py"])
+    subprocess.check_call(["python3", "run_info/engine_info.py"])
+    subprocess.check_call(["python3", "run_info/param_info.py"])
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -190,6 +195,15 @@ def main():
     # run benchmarks to obtain runtime data
     run_benchmarks(
         benchmarks_to_run, args.engines, "results", path, show_output=args.show_output
+    )
+    # get information about the compiler, engines, and args used for this run
+    get_run_info()
+    # Save a copy of the compiler/engine/arg info to the results directory
+    for filename in ["compiler_info", "engine_info", "param_info"]:
+        subprocess.check_call(
+            ["cp", f"out/{filename}.json",
+                f"bench_results/{path}/{filename}.json"
+            ]
     )
     # make runtime charts
     subprocess.check_call(

--- a/bench.py
+++ b/bench.py
@@ -39,7 +39,7 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
             "--warmup",
             "1",
             "--runs",
-            "3",
+            "10",
             "--export-json",
             f"bench_results/{path}/{filename}_wasmfx.json",
             "--export-csv",
@@ -63,7 +63,7 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
             "--warmup",
             "1",
             "--runs",
-            "3",
+            "10",
             "--export-json",
             f"bench_results/{path}/{filename}_asyncify.json",
             "--export-csv",
@@ -81,7 +81,6 @@ def run_benchmarks(benchmarks, engines, filename, path, show_output=False):
         ] + (["--show-output"] if show_output else [])
     )
 
-
 def get_binary_sizes(benchmarks, filename, path):
     data = []
     for benchmark in benchmarks:
@@ -96,11 +95,10 @@ def get_binary_sizes(benchmarks, filename, path):
     with open(f"bench_results/{path}/{filename}.json", "w") as f:
         json.dump(data, f)
 
-def get_run_info():
-    # Run the three scripts in ../run_info
-    subprocess.check_call(["python3", "run_info/compiler_info.py"])
-    subprocess.check_call(["python3", "run_info/engine_info.py"])
-    subprocess.check_call(["python3", "run_info/param_info.py"])
+def get_run_info(out_dir):
+    subprocess.check_call(["python3", "run_info/compiler_info.py", out_dir])
+    subprocess.check_call(["python3", "run_info/engine_info.py", out_dir])
+    subprocess.check_call(["python3", "run_info/param_info.py", out_dir])
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -197,14 +195,7 @@ def main():
         benchmarks_to_run, args.engines, "results", path, show_output=args.show_output
     )
     # get information about the compiler, engines, and args used for this run
-    get_run_info()
-    # Save a copy of the compiler/engine/arg info to the results directory
-    for filename in ["compiler_info", "engine_info", "param_info"]:
-        subprocess.check_call(
-            ["cp", f"out/{filename}.json",
-                f"bench_results/{path}/{filename}.json"
-            ]
-    )
+    get_run_info(f"bench_results/{path}")
     # make runtime charts
     subprocess.check_call(
         [

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -81,6 +81,10 @@ for i, filename in enumerate(files):
     with open(filename) as f:
         data.extend(json.load(f)["results"])
 
+# Load JSON files containing compiler/engine/parameter info using hardcoded paths.
+compiler_details = json.load(open("out/compiler_info.json"))
+engine_details = json.load(open("out/engine_info.json"))
+param_details = json.load(open("out/param_info.json"))
 
 # Predicates for the hyperfine output json format, to filter results by
 # benchmark, engine, and style (wasmfx vs asyncify).
@@ -194,10 +198,10 @@ ratio_stddev = ratio * np.sqrt(
 bar_loc = array_positions(ratio)
 
 # Plot the data
-fig, ax = plt.subplots()
+fig, (ax1, ax2) = plt.subplots(2,1, figsize=(10, 10), gridspec_kw={'height_ratios': [3, 1]})
 
 for i in range(len(ratio)):
-    ax.bar(
+    ax1.bar(
         bar_loc[i],
         ratio[i],
         width,
@@ -207,18 +211,18 @@ for i in range(len(ratio)):
 
 # Pad out list of engines to match number of benchmarks, so x-axis labels are engines
 axis_labels = np.repeat(engines, len(benches))
-ax.set_xticks(np.array(bar_loc).transpose().flatten(), axis_labels)
+ax1.set_xticks(np.array(bar_loc).transpose().flatten(), axis_labels)
 
 # Keeps every nth label, make the rest invisible
 n = len(benches)
 [
     l.set_visible(False)
-    for (i, l) in enumerate(ax.xaxis.get_ticklabels())
+    for (i, l) in enumerate(ax1.xaxis.get_ticklabels())
     if i % n != math.ceil(n / 2) - 1
 ]
 
 # Error bars
-plt.errorbar(
+ax1.errorbar(
     np.array(bar_loc).flatten(),
     ratio.flatten(),
     yerr=ratio_stddev.flatten(),
@@ -230,14 +234,49 @@ plt.errorbar(
 )
 
 # Readability features
-ax.grid(visible=True, axis="y")
-plt.title("Benchmark results (Asyncify time / WasmFX time)")
-plt.xlabel("Engine")
-plt.ylabel("Speedup (relative to Asyncify)")
-plt.legend(benches, bbox_to_anchor=(1.3, 1), loc="upper right")
+ax1.set(title="Benchmark results (Asyncify time / WasmFX time)", 
+        xlabel="Engine", 
+        ylabel="Speedup (relative to Asyncify)",
+)
+
+ax1.grid(visible=True, axis="y")
+
+ax1.legend(benches, loc="upper right")
 
 # Add a horizontal line at y=1 to indicate where wasmfx and asyncify have equal performance
-plt.axhline(y=1.0, color="r", linestyle="--", linewidth=3, label="WasmFX = Asyncify")
+ax1.axhline(y=1.0, color="r", linestyle="--", linewidth=3, label="WasmFX = Asyncify")
+
+# Add text to ax2
+ax2.axis([0, 10, 0, 10])
+ax2.tick_params(axis='x', colors='white')
+ax2.tick_params(axis='y', colors='white')
+
+# Generate string containing compiler info
+compile_info = "\n".join([
+    compiler_details["wasm_opt_ver"] 
+        + "with " 
+        + compiler_details["wasm_opt_flags"],
+    compiler_details["wasicc_ver"] 
+        + "with " 
+        + compiler_details["wasicc_flags"],
+    compiler_details["wasmfxtime_ver"]
+])
+
+# Generate string containing engine info, based on the engines that were used in this run
+engine_info = "\n".join([engine_details[engine] for engine in engines])
+
+# Do the same for benchmark arguments
+args_info = "\n".join([bench + ": " + param_details[bench] for bench in benches])
+
+# Now put these on the lower subplot.
+ax2.text(0.5, 8, 'Compilation info', weight='bold', fontsize=10)
+ax2.text(0.5, 5.5, compile_info, fontsize=9 )
+
+ax2.text(5.5, 8, 'Benchmark arguments', weight='bold', fontsize=10)
+ax2.text(5.5, 4.5, args_info, fontsize=9 )
+
+ax2.text(0.5, 4, 'Engine info', weight='bold', fontsize=10)
+ax2.text(0.5, 1.5, engine_info, fontsize=9 )
 
 # Export figure
 if args.output:
@@ -259,9 +298,10 @@ for i, engine in enumerate(engines):
     bar_loc = array_positions(engine_data)
 
     # Plot data
-    fig, ax = plt.subplots()
+    fig, (ax1, ax2) = plt.subplots(2,1, figsize=(10, 10), gridspec_kw={'height_ratios': [3, 1]})
+
     for j in range(len(styles)):
-        ax.bar(
+        ax1.bar(
             bar_loc[j],
             engine_data[j],
             width,
@@ -271,17 +311,17 @@ for i, engine in enumerate(engines):
 
     # Pad out list of engines to match number of benchmarks, so x-axis labels are engines
     axis_labels = np.repeat(benches, 2)
-    ax.set_xticks(np.array(bar_loc).transpose().flatten(), axis_labels)
+    ax1.set_xticks(np.array(bar_loc).transpose().flatten(), axis_labels)
 
     # Keeps every other label, make the rest invisible
     [
         l.set_visible(False)
-        for (i, l) in enumerate(ax.xaxis.get_ticklabels())
+        for (i, l) in enumerate(ax1.xaxis.get_ticklabels())
         if (i + 1) % 2 == 0
     ]
 
     # Error bars
-    plt.errorbar(
+    ax1.errorbar(
         np.array(bar_loc).flatten(),
         engine_data.flatten(),
         yerr=engine_data_stddev.flatten(),
@@ -293,11 +333,28 @@ for i, engine in enumerate(engines):
     )
 
     # Readability features
-    ax.grid(visible=True, axis="y")
-    plt.title(f"Benchmark results (absolute times) for {engine}")
-    plt.xlabel("Benchmark")
-    plt.ylabel("Time (seconds)")
-    plt.legend(["WasmFX", "Asyncify"], bbox_to_anchor=(1.3, 1), loc="upper right")
+    ax1.set(title=f"Benchmark results (absolute times) for {engine}", 
+        xlabel="Benchmark", 
+        ylabel="Time (seconds)",
+)
+    ax1.grid(visible=True, axis="y")
+
+    ax1.legend(["WasmFX", "Asyncify"], loc="upper right")
+
+    # Add text to ax2
+    ax2.axis([0, 10, 0, 10])
+    ax2.tick_params(axis='x', colors='white')
+    ax2.tick_params(axis='y', colors='white')
+
+    ax2.text(0.5, 8, 'Compilation info', weight='bold', fontsize=10)
+    ax2.text(0.5, 5.5, compile_info, fontsize=9 )
+
+    ax2.text(5.5, 8, 'Benchmark arguments', weight='bold', fontsize=10)
+    ax2.text(5.5, 4.5, args_info, fontsize=9 )
+
+    # Version of the current engine being charted
+    ax2.text(0.5, 4, 'Engine version', weight='bold', fontsize=10)
+    ax2.text(0.5, 3, engine_details[engine], fontsize=9 )
 
     # Export figure
     if args.output:
@@ -321,9 +378,10 @@ for i, benchmark in enumerate(benches):
     bar_loc = array_positions(bench_data)
 
     # Plot data
-    fig, ax = plt.subplots()
+    fig, (ax1, ax2) = plt.subplots(2,1, figsize=(10, 10), gridspec_kw={'height_ratios': [3, 1]})
+
     for i in range(len(bench_data)):
-        ax.bar(
+        ax1.bar(
             bar_loc[i],
             bench_data[i],
             width,
@@ -333,18 +391,18 @@ for i, benchmark in enumerate(benches):
 
     # Pad out list of benchmarks to match number of engines
     axis_labels = np.repeat(engines, 2)
-    ax.set_xticks(np.array(bar_loc).transpose().flatten(), axis_labels)
+    ax1.set_xticks(np.array(bar_loc).transpose().flatten(), axis_labels)
 
     # Keeps every other label, make the rest invisible
     n = len(engines)
     [
         l.set_visible(False)
-        for (i, l) in enumerate(ax.xaxis.get_ticklabels())
+        for (i, l) in enumerate(ax1.xaxis.get_ticklabels())
         if (i + 1) % 2 == 0
     ]
 
     # Error bars
-    plt.errorbar(
+    ax1.errorbar(
         np.array(bar_loc).flatten(),
         bench_data.flatten(),
         yerr=bench_data_stddev.flatten(),
@@ -356,11 +414,27 @@ for i, benchmark in enumerate(benches):
     )
 
     # Readability features
-    ax.grid(visible=True, axis="y")
-    plt.title(f"Benchmark results (absolute times) for {benchmark}")
-    plt.xlabel("Engine")
-    plt.ylabel("Time (seconds)")
-    plt.legend(["WasmFX", "Asyncify"], bbox_to_anchor=(1.3, 1), loc="upper right")
+    ax1.set(title=f"Benchmark results (absolute times) for {benchmark}", 
+        xlabel="Engine", 
+        ylabel="Time (seconds)",)
+    ax1.grid(visible=True, axis="y")
+    ax1.legend(["WasmFX", "Asyncify"], loc="upper right")
+
+    # Add text to ax2
+    ax2.axis([0, 10, 0, 10])
+    ax2.tick_params(axis='x', colors='white')
+    ax2.tick_params(axis='y', colors='white')
+
+    ax2.text(0.5, 8, 'Compilation info', weight='bold', fontsize=10)
+    ax2.text(0.5, 5.5, compile_info, fontsize=9 )
+
+    ax2.text(5.5, 8, f'Benchmark arguments ({benchmark})', weight='bold', fontsize=10)
+    ax2.text(5.5, 7, param_details[benchmark], fontsize=9 )
+
+    # Version of the current engine being charted
+    ax2.text(0.5, 4, 'Engine version', weight='bold', fontsize=10)
+    ax2.text(0.5, 1.5, engine_info, fontsize=9 )
+
 
     # Export figure
     if args.output:

--- a/plot_benchmarks.py
+++ b/plot_benchmarks.py
@@ -70,21 +70,25 @@ if os.path.isdir(args.files[0]):
             "files input should be a single dir with all benchmark results, or a list of json files."
         )
 
-    files = pathlib.Path(args.files[0]).glob("results_*.json")
+    results_files = pathlib.Path(args.files[0]).glob("results_*.json")
+    info_files = pathlib.Path(args.files[0]).glob("*_info.json")
 else:
-    files = args.files
+    results_files = [f for f in args.files if f.name.startswith("results_")]
+    info_files = [f for f in args.files if f.name.endswith("_info.json")]
 
 # Collect all the JSON data into a list of results we can query.
 data = []
-for i, filename in enumerate(files):
+for i, filename in enumerate(results_files):
     print(f"Loading data from {filename}...")
     with open(filename) as f:
         data.extend(json.load(f)["results"])
 
-# Load JSON files containing compiler/engine/parameter info using hardcoded paths.
-compiler_details = json.load(open("out/compiler_info.json"))
-engine_details = json.load(open("out/engine_info.json"))
-param_details = json.load(open("out/param_info.json"))
+# Load JSON files containing compiler/engine/parameter into a dict
+build_info = {}
+for i, filename in enumerate(info_files):
+    print(f"Loading build data from {filename}...")
+    with open(filename) as f:
+        build_info.update(json.load(f))
 
 # Predicates for the hyperfine output json format, to filter results by
 # benchmark, engine, and style (wasmfx vs asyncify).
@@ -253,20 +257,20 @@ ax2.tick_params(axis='y', colors='white')
 
 # Generate string containing compiler info
 compile_info = "\n".join([
-    compiler_details["wasm_opt_ver"] 
+    build_info["wasm_opt_ver"] 
         + "with " 
-        + compiler_details["wasm_opt_flags"],
-    compiler_details["wasicc_ver"] 
+        + build_info["wasm_opt_flags"],
+    build_info["wasicc_ver"] 
         + "with " 
-        + compiler_details["wasicc_flags"],
-    compiler_details["wasmfxtime_ver"]
+        + build_info["wasicc_flags"],
+    build_info["wasmfxtime_ver"]
 ])
 
 # Generate string containing engine info, based on the engines that were used in this run
-engine_info = "\n".join([engine_details[engine] for engine in engines])
+engine_info = "\n".join([build_info[engine] for engine in engines])
 
 # Do the same for benchmark arguments
-args_info = "\n".join([bench + ": " + param_details[bench] for bench in benches])
+args_info = "\n".join([bench + ": " + build_info[bench] for bench in benches])
 
 # Now put these on the lower subplot.
 ax2.text(0.5, 8, 'Compilation info', weight='bold', fontsize=10)
@@ -354,7 +358,7 @@ for i, engine in enumerate(engines):
 
     # Version of the current engine being charted
     ax2.text(0.5, 4, 'Engine version', weight='bold', fontsize=10)
-    ax2.text(0.5, 3, engine_details[engine], fontsize=9 )
+    ax2.text(0.5, 3, build_info[engine], fontsize=9 )
 
     # Export figure
     if args.output:
@@ -429,7 +433,7 @@ for i, benchmark in enumerate(benches):
     ax2.text(0.5, 5.5, compile_info, fontsize=9 )
 
     ax2.text(5.5, 8, f'Benchmark arguments ({benchmark})', weight='bold', fontsize=10)
-    ax2.text(5.5, 7, param_details[benchmark], fontsize=9 )
+    ax2.text(5.5, 7, build_info[benchmark], fontsize=9 )
 
     # Version of the current engine being charted
     ax2.text(0.5, 4, 'Engine version', weight='bold', fontsize=10)

--- a/run_info/compiler_info.mk
+++ b/run_info/compiler_info.mk
@@ -1,0 +1,18 @@
+# This makefile does the substitutions in the fiber-c config file.
+# silly but gets the job done!!
+
+CONFIG=make.config
+include ${CONFIG}
+
+dump:
+	@echo wasm_opt = $(WASM_OPT)
+	@echo wasm_opt_flags = $(WASM_OPT_FLAGS)
+	@echo asyncify = $(ASYNCIFY)
+	@echo asyncify_flags = $(ASYNCIFY_FLAGS)
+	@echo wasm_merge = $(WASM_MERGE)
+	@echo wasm_merge_flags = $(WASM_MERGE_FLAGS)
+	@echo wasicc = $(WASICC)
+	@echo wasi_flags = $(WASI_FLAGS)
+	@echo wasm_interp = $(WASM_INTERP)
+	@echo wasmfxtime = $(WASMTIME)
+	@echo wasmtime = $(WASMTIME_SWITCH)

--- a/run_info/compiler_info.py
+++ b/run_info/compiler_info.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+
+"""This script finds out the version and flags of compiler tools used for 
+    a particular benchmarking run."""
+
+import subprocess
+import json
+import os
+
+# Run makefile which dumps the compiler info
+data = subprocess.check_output(["make", "-f", "run_info/compiler_info.mk"], text=True)
+
+# Process this info into a dict
+config = {}
+
+for line in data.splitlines():
+    line = line.strip()
+    key, value = line.split("=", 1)
+    config[key.strip()] = value.strip()
+
+# Get version numbers of things
+wasm_opt_ver = subprocess.check_output([config["wasm_opt"], "--version"]).decode().split('\n', 1)[0]
+wasm_merge_ver = subprocess.check_output([config["wasm_merge"], "--version"]).decode().split('\n', 1)[0]
+wasicc_ver = subprocess.check_output([config["wasicc"], "-v"], stderr=subprocess.STDOUT).decode().split('\n', 1)[0]
+wasm_interp_ver = "TODO: figure out how to get version" #subprocess.check_output([config["wasm_interp"],"-v", "-e", "\"\""]).decode().split('\n', 1)[0]
+wasmfxtime_ver = subprocess.check_output([config["wasmfxtime"], "--version"]).decode().split('\n', 1)[0]
+# and this is wasmtime
+wasmtime_ver = subprocess.check_output([config["wasmtime"], "--version"]).decode().split('\n', 1)[0]
+
+# -------- Cleaning up the json --------
+
+# Here's a function that strips a string of a substring between brackets
+def strip_brackets(s):
+    start = s.find("(")
+    end = s.find(")", start)
+    if start != -1 and end != -1:
+        return s[:start] + s[end+1:]
+    return s
+
+# Extract version number from wasm_opt_ver (removing long number at the end)
+wasm_opt_ver = strip_brackets(wasm_opt_ver)
+
+# Extract -O flag from wasm_opt_flags
+wasm_opt_flags = config["wasm_opt_flags"]
+wasm_opt_flags = wasm_opt_flags[wasm_opt_flags.index("-O"):][:3]
+
+# Extract version number from wasicc_ver (removing long url at the end)
+wasicc_ver = strip_brackets(wasicc_ver)
+
+# Extract -O flag from waiscc_flags
+waiscc_flags = config["wasi_flags"]
+wasicc_flags = waiscc_flags[waiscc_flags.index("-O"):][:3]
+
+# Extract version number from wasmfxtime_ver (removing long number at the end)
+wasmfxtime_ver = strip_brackets(wasmfxtime_ver)
+
+# make the output directory if necessary
+os.makedirs(f"out", exist_ok=True)
+
+# Write this stuff to a json
+with open("out/compiler_info.json", "w") as f:
+    json.dump({
+        "wasm_opt_ver" : wasm_opt_ver,
+        "wasm_opt_flags" : wasm_opt_flags,
+        "wasicc_ver" : wasicc_ver,
+        "wasicc_flags" : wasicc_flags,
+        "wasmfxtime_ver" : wasmfxtime_ver,
+        # The commented out lines dump *all* info, which we might want at some point!
+        #"wasm_opt_flags" : config["wasm_opt_flags"],
+        #"asyncify_flags" : config["asyncify_flags"],
+        #"wasm_merge_ver" : wasm_merge_ver,
+        #"wasm_merge_flags" : config["wasm_merge_flags"],
+        #"wasicc_flags" : config["wasi_flags"],
+        #"wasm_interp_ver" : wasm_interp_ver,
+        #"wasmtime_ver" : wasmtime_ver,
+    }, f)

--- a/run_info/compiler_info.py
+++ b/run_info/compiler_info.py
@@ -57,23 +57,30 @@ wasicc_flags = waiscc_flags[waiscc_flags.index("-O"):][:3]
 # Extract version number from wasmfxtime_ver (removing long number at the end)
 wasmfxtime_ver = strip_brackets(wasmfxtime_ver)
 
-# make the output directory if necessary
-os.makedirs(f"out", exist_ok=True)
+def main(arg):
+    # make the output directory if necessary
+    os.makedirs(str(arg), exist_ok=True)
 
-# Write this stuff to a json
-with open("out/compiler_info.json", "w") as f:
-    json.dump({
-        "wasm_opt_ver" : wasm_opt_ver,
-        "wasm_opt_flags" : wasm_opt_flags,
-        "wasicc_ver" : wasicc_ver,
-        "wasicc_flags" : wasicc_flags,
-        "wasmfxtime_ver" : wasmfxtime_ver,
-        # The commented out lines dump *all* info, which we might want at some point!
-        #"wasm_opt_flags" : config["wasm_opt_flags"],
-        #"asyncify_flags" : config["asyncify_flags"],
-        #"wasm_merge_ver" : wasm_merge_ver,
-        #"wasm_merge_flags" : config["wasm_merge_flags"],
-        #"wasicc_flags" : config["wasi_flags"],
-        #"wasm_interp_ver" : wasm_interp_ver,
-        #"wasmtime_ver" : wasmtime_ver,
-    }, f)
+    # Write this stuff to a json
+    with open(f"{str(arg)}/compiler_info.json", "w") as f:
+        json.dump({
+            "wasm_opt_ver" : wasm_opt_ver,
+            "wasm_opt_flags" : wasm_opt_flags,
+            "wasicc_ver" : wasicc_ver,
+            "wasicc_flags" : wasicc_flags,
+            "wasmfxtime_ver" : wasmfxtime_ver,
+            # The commented out lines dump *all* info, which we might want at some point!
+            #"wasm_opt_flags" : config["wasm_opt_flags"],
+            #"asyncify_flags" : config["asyncify_flags"],
+            #"wasm_merge_ver" : wasm_merge_ver,
+            #"wasm_merge_flags" : config["wasm_merge_flags"],
+            #"wasicc_flags" : config["wasi_flags"],
+            #"wasm_interp_ver" : wasm_interp_ver,
+            #"wasmtime_ver" : wasmtime_ver,
+        }, f)
+
+if __name__ == "__main__":
+    import sys
+    # Set default output directory to "out" if no argument is provided
+    arg = sys.argv[1] if len(sys.argv) > 1 else "out"
+    main(arg)

--- a/run_info/engine_info.py
+++ b/run_info/engine_info.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+
+"""This script finds out the version and flags of each wasm engine used for 
+    a particular benchmarking run."""
+
+import yaml
+import subprocess
+import json
+import os
+
+config = yaml.safe_load(open("config.yml"))
+
+# Set up environment variables for directory containing engines, defaulting to `/opt/wasmfx`` if not set
+ENGINE_ROOT_DIR = os.getenv("ENGINE_ROOT_DIR", "/opt/wasmfx")
+
+# Run --version on each engine and write the output to a file.
+wasmtime_ver = subprocess.check_output([ENGINE_ROOT_DIR + config["WASMTIME_PATH"], "--version"])
+wasmtime_ver = wasmtime_ver.decode().split('\n', 1)[0]
+
+wizard_ver = subprocess.check_output([ENGINE_ROOT_DIR + config["WIZARD_PATH"], "--version"])
+wizard_ver = wizard_ver.decode().split('\n', 1)[0]
+
+v8_ver = subprocess.check_output(
+    [ENGINE_ROOT_DIR + config["D8_PATH"]],
+    input="quit()\n",
+    text=True
+)
+v8_ver = v8_ver.split('\n', 1)[0]
+
+# make the output directory if necessary
+os.makedirs(f"out", exist_ok=True)
+
+# Write this stuff to a json
+with open("out/engine_info.json", "w") as f:
+    json.dump({
+        "wasmtime": wasmtime_ver,
+        #"wasmtime_flags": config["WASMTIME_OPTIONS"],
+        "wizard": wizard_ver,
+        #"wizard_flags": config["WIZARD_OPTIONS"],
+        "d8": v8_ver,
+        #"v8_flags": config["D8_OPTIONS"],
+    }, f)

--- a/run_info/engine_info.py
+++ b/run_info/engine_info.py
@@ -23,23 +23,26 @@ wasmtime_ver = wasmtime_ver.decode().split('\n', 1)[0]
 wizard_ver = subprocess.check_output([ENGINE_ROOT_DIR + config["WIZARD_PATH"], "--version"])
 wizard_ver = wizard_ver.decode().split('\n', 1)[0]
 
-v8_ver = subprocess.check_output(
-    [ENGINE_ROOT_DIR + config["D8_PATH"]],
-    input="quit()\n",
-    text=True
-)
-v8_ver = v8_ver.split('\n', 1)[0]
+v8_ver = subprocess.check_output([ENGINE_ROOT_DIR + config["D8_PATH"], "--version"])
+v8_ver = v8_ver.decode().split('\n', 1)[0]
 
-# make the output directory if necessary
-os.makedirs(f"out", exist_ok=True)
+def main(arg):
+    # make the output directory if necessary
+    os.makedirs(str(arg), exist_ok=True)
 
-# Write this stuff to a json
-with open("out/engine_info.json", "w") as f:
-    json.dump({
-        "wasmtime": wasmtime_ver,
-        #"wasmtime_flags": config["WASMTIME_OPTIONS"],
-        "wizard": wizard_ver,
-        #"wizard_flags": config["WIZARD_OPTIONS"],
-        "d8": v8_ver,
-        #"v8_flags": config["D8_OPTIONS"],
-    }, f)
+    # Write this stuff to a json
+    with open(f"{str(arg)}/engine_info.json", "w") as f:
+        json.dump({
+            "wasmtime": wasmtime_ver,
+            #"wasmtime_flags": config["WASMTIME_OPTIONS"],
+            "wizard": wizard_ver,
+            #"wizard_flags": config["WIZARD_OPTIONS"],
+            "d8": v8_ver,
+            #"v8_flags": config["D8_OPTIONS"],
+        }, f)
+
+if __name__ == "__main__":
+    import sys
+    # Set default output directory to "out" if no argument is provided
+    arg = sys.argv[1] if len(sys.argv) > 1 else "out"
+    main(arg)

--- a/run_info/param_info.py
+++ b/run_info/param_info.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+
+"""This script dumps the parameters each benchmark was run with."""
+
+import yaml
+import subprocess
+import os
+import json
+
+# We get the treesum and itersum params from the config file.
+config = yaml.safe_load(open("config.yml"))
+
+# We sed the pi and scheduler params
+
+# sed commands to get number of fibers arguments for pi and scheduler benchmarks
+pi_tasks_cmd = """awk '/#define NUM_TASKS/ { sub(".* ", ""); print }' examples/pi.c"""
+scheduler_workers_cmd = """awk '/#define NUM_WORKERS/ { sub(".* ", ""); print }' examples/scheduler.c"""
+
+# now run those commands
+pi_tasks_param = subprocess.check_output(pi_tasks_cmd, shell=True, text=True).strip()
+scheduler_workers_param = subprocess.check_output(scheduler_workers_cmd, shell=True, text=True).strip()
+
+# Then sed the number of context switches
+pi_yields_cmd = """awk '/YIELDS =/ { sub(".* ", ""); gsub(/;/, ""); print }' examples/pi.c"""
+scheduler_switches_cmd = """awk '/#define SWITCHES/ { sub(".* ", ""); print }' examples/scheduler.c"""
+
+# run the commands
+pi_yields_param = subprocess.check_output(pi_yields_cmd, shell=True, text=True).strip()
+scheduler_switches_param = subprocess.check_output(scheduler_switches_cmd, shell=True, text=True).strip()
+
+# make the output directory if necessary
+os.makedirs(f"out", exist_ok=True)
+
+with open("out/param_info.json", "w") as f:
+    json.dump({
+        "treesum": str(config["BENCHMARK_ARGS"]["treesum"]),
+        "itersum": str(config["BENCHMARK_ARGS"]["itersum"]),
+        "pi": 
+            ("tasks= " + pi_tasks_param + ", yields= " + pi_yields_param),
+        "scheduler": 
+            ("workers= " + scheduler_workers_param + ", switches= " + scheduler_switches_param),
+        "c10m" : "N/A",
+    }, f)

--- a/run_info/param_info.py
+++ b/run_info/param_info.py
@@ -13,34 +13,31 @@ import json
 # We get the treesum and itersum params from the config file.
 config = yaml.safe_load(open("config.yml"))
 
-# We sed the pi and scheduler params
-
-# sed commands to get number of fibers arguments for pi and scheduler benchmarks
-pi_tasks_cmd = """awk '/#define NUM_TASKS/ { sub(".* ", ""); print }' examples/pi.c"""
-scheduler_workers_cmd = """awk '/#define NUM_WORKERS/ { sub(".* ", ""); print }' examples/scheduler.c"""
-
-# now run those commands
-pi_tasks_param = subprocess.check_output(pi_tasks_cmd, shell=True, text=True).strip()
-scheduler_workers_param = subprocess.check_output(scheduler_workers_cmd, shell=True, text=True).strip()
+# We sed the pi and scheduler for number of fibers
+pi_tasks_param = subprocess.check_output(["awk", '/#define NUM_TASKS/ { sub(".* ", ""); print }', "examples/pi.c"], text=True).strip()
+scheduler_workers_param = subprocess.check_output(["awk", '/#define NUM_WORKERS/ { sub(".* ", ""); print }', "examples/scheduler.c"], text=True).strip()
 
 # Then sed the number of context switches
-pi_yields_cmd = """awk '/YIELDS =/ { sub(".* ", ""); gsub(/;/, ""); print }' examples/pi.c"""
-scheduler_switches_cmd = """awk '/#define SWITCHES/ { sub(".* ", ""); print }' examples/scheduler.c"""
+pi_yields_param = subprocess.check_output(["awk", '/YIELDS =/ { sub(".* ", ""); gsub(/;/, ""); print }', "examples/pi.c"], text=True).strip()
+scheduler_switches_param = subprocess.check_output(["awk", '/#define SWITCHES/ { sub(".* ", ""); print }', "examples/scheduler.c"], text=True).strip()
 
-# run the commands
-pi_yields_param = subprocess.check_output(pi_yields_cmd, shell=True, text=True).strip()
-scheduler_switches_param = subprocess.check_output(scheduler_switches_cmd, shell=True, text=True).strip()
+def main(arg):
+    # make the output directory if necessary
+    os.makedirs(str(arg), exist_ok=True)
 
-# make the output directory if necessary
-os.makedirs(f"out", exist_ok=True)
+    with open(f"{str(arg)}/param_info.json", "w") as f:
+        json.dump({
+            "treesum": str(config["BENCHMARK_ARGS"]["treesum"]),
+            "itersum": str(config["BENCHMARK_ARGS"]["itersum"]),
+            "pi": 
+                ("tasks= " + pi_tasks_param + ", yields= " + pi_yields_param),
+            "scheduler": 
+                ("workers= " + scheduler_workers_param + ", switches= " + scheduler_switches_param),
+            "c10m" : "N/A",
+        }, f)
 
-with open("out/param_info.json", "w") as f:
-    json.dump({
-        "treesum": str(config["BENCHMARK_ARGS"]["treesum"]),
-        "itersum": str(config["BENCHMARK_ARGS"]["itersum"]),
-        "pi": 
-            ("tasks= " + pi_tasks_param + ", yields= " + pi_yields_param),
-        "scheduler": 
-            ("workers= " + scheduler_workers_param + ", switches= " + scheduler_switches_param),
-        "c10m" : "N/A",
-    }, f)
+if __name__ == "__main__":
+    import sys
+    # Set default output directory to "out" if no argument is provided
+    arg = sys.argv[1] if len(sys.argv) > 1 else "out"
+    main(arg)


### PR DESCRIPTION
Now we can keep track of the compiler/engine versions and flags used in a particular benchmarking run, as well as the arguments the benchmarks were fed.