### PR TITLE
Factor out parameters for pi, pi_switch, scheduler, scheduler_switch into a header file

### DIFF
--- a/examples/params.h
+++ b/examples/params.h
@@ -1,0 +1,16 @@
+#ifndef PARAMS_H
+#define PARAMS_H
+
+// Turn output on/off
+#define PRINT_RESULTS 0
+
+// Parameters for pi and pi_switch
+#define NUM_TASKS     1000
+#define BATCH_SIZE    20000U
+#define YIELDS        50U
+
+// Parameters for scheduler and scheduler_switch
+#define NUM_WORKERS   10
+#define SWITCHES      10000000
+
+#endif

--- a/examples/pi.c
+++ b/examples/pi.c
@@ -9,13 +9,8 @@
 
 #include <fiber.h>
 
-// Parameters
-#define PRINT_RESULTS 0
-#define NUM_TASKS 1000
-// Number of samples taken between yields.
-static uint32_t const BATCH_SIZE = 20000;
-// Number of batches to run in total. Each fiber will take YIELDS * BATCH_SIZE samples
-static uint32_t const YIELDS = 50;
+// Values for `PRINT_RESULTS`, `NUM_TASKS`, `BATCH_SIZE`, `YIELDS`
+#include "params.h"
 
 // Global state for scheduler
 bool keep_going = true;

--- a/examples/pi_switch.c
+++ b/examples/pi_switch.c
@@ -9,13 +9,8 @@
 
 #include <fiber_switch.h>
 
-// Parameters
-#define PRINT_RESULTS 0
-#define NUM_TASKS 1000
-// Number of samples taken between yields.
-static uint32_t const BATCH_SIZE = 100000;
-// Number of batches to run in total. Each fiber will take YIELDS * BATCH_SIZE samples
-static uint32_t const YIELDS = 50;
+// Values for `PRINT_RESULTS`, `NUM_TASKS`, `BATCH_SIZE`, `YIELDS`
+#include "params.h"
 
 // Array of results
 static double results[NUM_TASKS];
@@ -125,6 +120,3 @@ int main(int argc, char **argv) {
 
   return 0;
 }
-
-#undef PRINT_RESULTS
-#undef NUM_TASKS

--- a/examples/scheduler.c
+++ b/examples/scheduler.c
@@ -11,10 +11,8 @@
 
 #include <fiber.h>
 
-// Parameters
-#define PRINT_RESULTS 0
-#define NUM_WORKERS 10
-#define SWITCHES 10000000
+// Values for `NUM_WORKERS` and `SWITCHES`
+#include "params.h"
 
 // Global state for scheduler
 bool keep_going = true;

--- a/examples/scheduler_switch.c
+++ b/examples/scheduler_switch.c
@@ -10,10 +10,8 @@
 
 #include <fiber_switch.h>
 
-// Parameters
-#define PRINT_RESULTS 0
-#define NUM_WORKERS 10
-#define SWITCHES 10000000
+// Values for `NUM_WORKERS` and `SWITCHES`
+#include "params.h"
 
 // Array of workers
 static fiber_t workers[NUM_WORKERS];


### PR DESCRIPTION
I was having problems with keeping track of the parameters in `#define`s. 

This also ensures pi/pi_switch and scheduler/scheduler_switch have the same parameters.